### PR TITLE
[codex] Add Gmail-style message threads

### DIFF
--- a/lib/data/local/app_database.dart
+++ b/lib/data/local/app_database.dart
@@ -53,12 +53,16 @@ class MessageSummaries extends Table {
 class MessageDetails extends Table {
   TextColumn get id => text()();
   TextColumn get accountId => text().withDefault(const Constant('default'))();
+  TextColumn get folderId => text().withDefault(const Constant(''))();
   TextColumn get subject => text()();
   TextColumn get sender => text()();
   TextColumn get recipients => text()();
   TextColumn get bodyPlain => text()();
   TextColumn get bodyHtml => text().nullable()();
   DateTimeColumn get receivedAt => dateTime()();
+  TextColumn get messageIdHeader => text().nullable()();
+  TextColumn get inReplyToHeader => text().nullable()();
+  TextColumn get referencesHeader => text().nullable()();
 
   @override
   Set<Column<Object>> get primaryKey => {id};
@@ -100,7 +104,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -112,6 +116,21 @@ class AppDatabase extends _$AppDatabase {
         await migrator.addColumn(
           attachmentMetadata,
           attachmentMetadata.accountId,
+        );
+      }
+      if (from < 3) {
+        await migrator.addColumn(messageDetails, messageDetails.folderId);
+        await migrator.addColumn(
+          messageDetails,
+          messageDetails.messageIdHeader,
+        );
+        await migrator.addColumn(
+          messageDetails,
+          messageDetails.inReplyToHeader,
+        );
+        await migrator.addColumn(
+          messageDetails,
+          messageDetails.referencesHeader,
         );
       }
     },

--- a/lib/data/local/app_database.g.dart
+++ b/lib/data/local/app_database.g.dart
@@ -1620,6 +1620,18 @@ class $MessageDetailsTable extends MessageDetails
     requiredDuringInsert: false,
     defaultValue: const Constant('default'),
   );
+  static const VerificationMeta _folderIdMeta = const VerificationMeta(
+    'folderId',
+  );
+  @override
+  late final GeneratedColumn<String> folderId = GeneratedColumn<String>(
+    'folder_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(''),
+  );
   static const VerificationMeta _subjectMeta = const VerificationMeta(
     'subject',
   );
@@ -1684,16 +1696,53 @@ class $MessageDetailsTable extends MessageDetails
     type: DriftSqlType.dateTime,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _messageIdHeaderMeta = const VerificationMeta(
+    'messageIdHeader',
+  );
+  @override
+  late final GeneratedColumn<String> messageIdHeader = GeneratedColumn<String>(
+    'message_id_header',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _inReplyToHeaderMeta = const VerificationMeta(
+    'inReplyToHeader',
+  );
+  @override
+  late final GeneratedColumn<String> inReplyToHeader = GeneratedColumn<String>(
+    'in_reply_to_header',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _referencesHeaderMeta = const VerificationMeta(
+    'referencesHeader',
+  );
+  @override
+  late final GeneratedColumn<String> referencesHeader = GeneratedColumn<String>(
+    'references_header',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
     accountId,
+    folderId,
     subject,
     sender,
     recipients,
     bodyPlain,
     bodyHtml,
     receivedAt,
+    messageIdHeader,
+    inReplyToHeader,
+    referencesHeader,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -1716,6 +1765,12 @@ class $MessageDetailsTable extends MessageDetails
       context.handle(
         _accountIdMeta,
         accountId.isAcceptableOrUnknown(data['account_id']!, _accountIdMeta),
+      );
+    }
+    if (data.containsKey('folder_id')) {
+      context.handle(
+        _folderIdMeta,
+        folderId.isAcceptableOrUnknown(data['folder_id']!, _folderIdMeta),
       );
     }
     if (data.containsKey('subject')) {
@@ -1764,6 +1819,33 @@ class $MessageDetailsTable extends MessageDetails
     } else if (isInserting) {
       context.missing(_receivedAtMeta);
     }
+    if (data.containsKey('message_id_header')) {
+      context.handle(
+        _messageIdHeaderMeta,
+        messageIdHeader.isAcceptableOrUnknown(
+          data['message_id_header']!,
+          _messageIdHeaderMeta,
+        ),
+      );
+    }
+    if (data.containsKey('in_reply_to_header')) {
+      context.handle(
+        _inReplyToHeaderMeta,
+        inReplyToHeader.isAcceptableOrUnknown(
+          data['in_reply_to_header']!,
+          _inReplyToHeaderMeta,
+        ),
+      );
+    }
+    if (data.containsKey('references_header')) {
+      context.handle(
+        _referencesHeaderMeta,
+        referencesHeader.isAcceptableOrUnknown(
+          data['references_header']!,
+          _referencesHeaderMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -1780,6 +1862,10 @@ class $MessageDetailsTable extends MessageDetails
       accountId: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}account_id'],
+      )!,
+      folderId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}folder_id'],
       )!,
       subject: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
@@ -1805,6 +1891,18 @@ class $MessageDetailsTable extends MessageDetails
         DriftSqlType.dateTime,
         data['${effectivePrefix}received_at'],
       )!,
+      messageIdHeader: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}message_id_header'],
+      ),
+      inReplyToHeader: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}in_reply_to_header'],
+      ),
+      referencesHeader: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}references_header'],
+      ),
     );
   }
 
@@ -1817,27 +1915,36 @@ class $MessageDetailsTable extends MessageDetails
 class MessageDetail extends DataClass implements Insertable<MessageDetail> {
   final String id;
   final String accountId;
+  final String folderId;
   final String subject;
   final String sender;
   final String recipients;
   final String bodyPlain;
   final String? bodyHtml;
   final DateTime receivedAt;
+  final String? messageIdHeader;
+  final String? inReplyToHeader;
+  final String? referencesHeader;
   const MessageDetail({
     required this.id,
     required this.accountId,
+    required this.folderId,
     required this.subject,
     required this.sender,
     required this.recipients,
     required this.bodyPlain,
     this.bodyHtml,
     required this.receivedAt,
+    this.messageIdHeader,
+    this.inReplyToHeader,
+    this.referencesHeader,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<String>(id);
     map['account_id'] = Variable<String>(accountId);
+    map['folder_id'] = Variable<String>(folderId);
     map['subject'] = Variable<String>(subject);
     map['sender'] = Variable<String>(sender);
     map['recipients'] = Variable<String>(recipients);
@@ -1846,6 +1953,15 @@ class MessageDetail extends DataClass implements Insertable<MessageDetail> {
       map['body_html'] = Variable<String>(bodyHtml);
     }
     map['received_at'] = Variable<DateTime>(receivedAt);
+    if (!nullToAbsent || messageIdHeader != null) {
+      map['message_id_header'] = Variable<String>(messageIdHeader);
+    }
+    if (!nullToAbsent || inReplyToHeader != null) {
+      map['in_reply_to_header'] = Variable<String>(inReplyToHeader);
+    }
+    if (!nullToAbsent || referencesHeader != null) {
+      map['references_header'] = Variable<String>(referencesHeader);
+    }
     return map;
   }
 
@@ -1853,6 +1969,7 @@ class MessageDetail extends DataClass implements Insertable<MessageDetail> {
     return MessageDetailsCompanion(
       id: Value(id),
       accountId: Value(accountId),
+      folderId: Value(folderId),
       subject: Value(subject),
       sender: Value(sender),
       recipients: Value(recipients),
@@ -1861,6 +1978,15 @@ class MessageDetail extends DataClass implements Insertable<MessageDetail> {
           ? const Value.absent()
           : Value(bodyHtml),
       receivedAt: Value(receivedAt),
+      messageIdHeader: messageIdHeader == null && nullToAbsent
+          ? const Value.absent()
+          : Value(messageIdHeader),
+      inReplyToHeader: inReplyToHeader == null && nullToAbsent
+          ? const Value.absent()
+          : Value(inReplyToHeader),
+      referencesHeader: referencesHeader == null && nullToAbsent
+          ? const Value.absent()
+          : Value(referencesHeader),
     );
   }
 
@@ -1872,12 +1998,16 @@ class MessageDetail extends DataClass implements Insertable<MessageDetail> {
     return MessageDetail(
       id: serializer.fromJson<String>(json['id']),
       accountId: serializer.fromJson<String>(json['accountId']),
+      folderId: serializer.fromJson<String>(json['folderId']),
       subject: serializer.fromJson<String>(json['subject']),
       sender: serializer.fromJson<String>(json['sender']),
       recipients: serializer.fromJson<String>(json['recipients']),
       bodyPlain: serializer.fromJson<String>(json['bodyPlain']),
       bodyHtml: serializer.fromJson<String?>(json['bodyHtml']),
       receivedAt: serializer.fromJson<DateTime>(json['receivedAt']),
+      messageIdHeader: serializer.fromJson<String?>(json['messageIdHeader']),
+      inReplyToHeader: serializer.fromJson<String?>(json['inReplyToHeader']),
+      referencesHeader: serializer.fromJson<String?>(json['referencesHeader']),
     );
   }
   @override
@@ -1886,38 +2016,57 @@ class MessageDetail extends DataClass implements Insertable<MessageDetail> {
     return <String, dynamic>{
       'id': serializer.toJson<String>(id),
       'accountId': serializer.toJson<String>(accountId),
+      'folderId': serializer.toJson<String>(folderId),
       'subject': serializer.toJson<String>(subject),
       'sender': serializer.toJson<String>(sender),
       'recipients': serializer.toJson<String>(recipients),
       'bodyPlain': serializer.toJson<String>(bodyPlain),
       'bodyHtml': serializer.toJson<String?>(bodyHtml),
       'receivedAt': serializer.toJson<DateTime>(receivedAt),
+      'messageIdHeader': serializer.toJson<String?>(messageIdHeader),
+      'inReplyToHeader': serializer.toJson<String?>(inReplyToHeader),
+      'referencesHeader': serializer.toJson<String?>(referencesHeader),
     };
   }
 
   MessageDetail copyWith({
     String? id,
     String? accountId,
+    String? folderId,
     String? subject,
     String? sender,
     String? recipients,
     String? bodyPlain,
     Value<String?> bodyHtml = const Value.absent(),
     DateTime? receivedAt,
+    Value<String?> messageIdHeader = const Value.absent(),
+    Value<String?> inReplyToHeader = const Value.absent(),
+    Value<String?> referencesHeader = const Value.absent(),
   }) => MessageDetail(
     id: id ?? this.id,
     accountId: accountId ?? this.accountId,
+    folderId: folderId ?? this.folderId,
     subject: subject ?? this.subject,
     sender: sender ?? this.sender,
     recipients: recipients ?? this.recipients,
     bodyPlain: bodyPlain ?? this.bodyPlain,
     bodyHtml: bodyHtml.present ? bodyHtml.value : this.bodyHtml,
     receivedAt: receivedAt ?? this.receivedAt,
+    messageIdHeader: messageIdHeader.present
+        ? messageIdHeader.value
+        : this.messageIdHeader,
+    inReplyToHeader: inReplyToHeader.present
+        ? inReplyToHeader.value
+        : this.inReplyToHeader,
+    referencesHeader: referencesHeader.present
+        ? referencesHeader.value
+        : this.referencesHeader,
   );
   MessageDetail copyWithCompanion(MessageDetailsCompanion data) {
     return MessageDetail(
       id: data.id.present ? data.id.value : this.id,
       accountId: data.accountId.present ? data.accountId.value : this.accountId,
+      folderId: data.folderId.present ? data.folderId.value : this.folderId,
       subject: data.subject.present ? data.subject.value : this.subject,
       sender: data.sender.present ? data.sender.value : this.sender,
       recipients: data.recipients.present
@@ -1928,6 +2077,15 @@ class MessageDetail extends DataClass implements Insertable<MessageDetail> {
       receivedAt: data.receivedAt.present
           ? data.receivedAt.value
           : this.receivedAt,
+      messageIdHeader: data.messageIdHeader.present
+          ? data.messageIdHeader.value
+          : this.messageIdHeader,
+      inReplyToHeader: data.inReplyToHeader.present
+          ? data.inReplyToHeader.value
+          : this.inReplyToHeader,
+      referencesHeader: data.referencesHeader.present
+          ? data.referencesHeader.value
+          : this.referencesHeader,
     );
   }
 
@@ -1936,12 +2094,16 @@ class MessageDetail extends DataClass implements Insertable<MessageDetail> {
     return (StringBuffer('MessageDetail(')
           ..write('id: $id, ')
           ..write('accountId: $accountId, ')
+          ..write('folderId: $folderId, ')
           ..write('subject: $subject, ')
           ..write('sender: $sender, ')
           ..write('recipients: $recipients, ')
           ..write('bodyPlain: $bodyPlain, ')
           ..write('bodyHtml: $bodyHtml, ')
-          ..write('receivedAt: $receivedAt')
+          ..write('receivedAt: $receivedAt, ')
+          ..write('messageIdHeader: $messageIdHeader, ')
+          ..write('inReplyToHeader: $inReplyToHeader, ')
+          ..write('referencesHeader: $referencesHeader')
           ..write(')'))
         .toString();
   }
@@ -1950,12 +2112,16 @@ class MessageDetail extends DataClass implements Insertable<MessageDetail> {
   int get hashCode => Object.hash(
     id,
     accountId,
+    folderId,
     subject,
     sender,
     recipients,
     bodyPlain,
     bodyHtml,
     receivedAt,
+    messageIdHeader,
+    inReplyToHeader,
+    referencesHeader,
   );
   @override
   bool operator ==(Object other) =>
@@ -1963,44 +2129,60 @@ class MessageDetail extends DataClass implements Insertable<MessageDetail> {
       (other is MessageDetail &&
           other.id == this.id &&
           other.accountId == this.accountId &&
+          other.folderId == this.folderId &&
           other.subject == this.subject &&
           other.sender == this.sender &&
           other.recipients == this.recipients &&
           other.bodyPlain == this.bodyPlain &&
           other.bodyHtml == this.bodyHtml &&
-          other.receivedAt == this.receivedAt);
+          other.receivedAt == this.receivedAt &&
+          other.messageIdHeader == this.messageIdHeader &&
+          other.inReplyToHeader == this.inReplyToHeader &&
+          other.referencesHeader == this.referencesHeader);
 }
 
 class MessageDetailsCompanion extends UpdateCompanion<MessageDetail> {
   final Value<String> id;
   final Value<String> accountId;
+  final Value<String> folderId;
   final Value<String> subject;
   final Value<String> sender;
   final Value<String> recipients;
   final Value<String> bodyPlain;
   final Value<String?> bodyHtml;
   final Value<DateTime> receivedAt;
+  final Value<String?> messageIdHeader;
+  final Value<String?> inReplyToHeader;
+  final Value<String?> referencesHeader;
   final Value<int> rowid;
   const MessageDetailsCompanion({
     this.id = const Value.absent(),
     this.accountId = const Value.absent(),
+    this.folderId = const Value.absent(),
     this.subject = const Value.absent(),
     this.sender = const Value.absent(),
     this.recipients = const Value.absent(),
     this.bodyPlain = const Value.absent(),
     this.bodyHtml = const Value.absent(),
     this.receivedAt = const Value.absent(),
+    this.messageIdHeader = const Value.absent(),
+    this.inReplyToHeader = const Value.absent(),
+    this.referencesHeader = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   MessageDetailsCompanion.insert({
     required String id,
     this.accountId = const Value.absent(),
+    this.folderId = const Value.absent(),
     required String subject,
     required String sender,
     required String recipients,
     required String bodyPlain,
     this.bodyHtml = const Value.absent(),
     required DateTime receivedAt,
+    this.messageIdHeader = const Value.absent(),
+    this.inReplyToHeader = const Value.absent(),
+    this.referencesHeader = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
        subject = Value(subject),
@@ -2011,23 +2193,31 @@ class MessageDetailsCompanion extends UpdateCompanion<MessageDetail> {
   static Insertable<MessageDetail> custom({
     Expression<String>? id,
     Expression<String>? accountId,
+    Expression<String>? folderId,
     Expression<String>? subject,
     Expression<String>? sender,
     Expression<String>? recipients,
     Expression<String>? bodyPlain,
     Expression<String>? bodyHtml,
     Expression<DateTime>? receivedAt,
+    Expression<String>? messageIdHeader,
+    Expression<String>? inReplyToHeader,
+    Expression<String>? referencesHeader,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (accountId != null) 'account_id': accountId,
+      if (folderId != null) 'folder_id': folderId,
       if (subject != null) 'subject': subject,
       if (sender != null) 'sender': sender,
       if (recipients != null) 'recipients': recipients,
       if (bodyPlain != null) 'body_plain': bodyPlain,
       if (bodyHtml != null) 'body_html': bodyHtml,
       if (receivedAt != null) 'received_at': receivedAt,
+      if (messageIdHeader != null) 'message_id_header': messageIdHeader,
+      if (inReplyToHeader != null) 'in_reply_to_header': inReplyToHeader,
+      if (referencesHeader != null) 'references_header': referencesHeader,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -2035,23 +2225,31 @@ class MessageDetailsCompanion extends UpdateCompanion<MessageDetail> {
   MessageDetailsCompanion copyWith({
     Value<String>? id,
     Value<String>? accountId,
+    Value<String>? folderId,
     Value<String>? subject,
     Value<String>? sender,
     Value<String>? recipients,
     Value<String>? bodyPlain,
     Value<String?>? bodyHtml,
     Value<DateTime>? receivedAt,
+    Value<String?>? messageIdHeader,
+    Value<String?>? inReplyToHeader,
+    Value<String?>? referencesHeader,
     Value<int>? rowid,
   }) {
     return MessageDetailsCompanion(
       id: id ?? this.id,
       accountId: accountId ?? this.accountId,
+      folderId: folderId ?? this.folderId,
       subject: subject ?? this.subject,
       sender: sender ?? this.sender,
       recipients: recipients ?? this.recipients,
       bodyPlain: bodyPlain ?? this.bodyPlain,
       bodyHtml: bodyHtml ?? this.bodyHtml,
       receivedAt: receivedAt ?? this.receivedAt,
+      messageIdHeader: messageIdHeader ?? this.messageIdHeader,
+      inReplyToHeader: inReplyToHeader ?? this.inReplyToHeader,
+      referencesHeader: referencesHeader ?? this.referencesHeader,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -2064,6 +2262,9 @@ class MessageDetailsCompanion extends UpdateCompanion<MessageDetail> {
     }
     if (accountId.present) {
       map['account_id'] = Variable<String>(accountId.value);
+    }
+    if (folderId.present) {
+      map['folder_id'] = Variable<String>(folderId.value);
     }
     if (subject.present) {
       map['subject'] = Variable<String>(subject.value);
@@ -2083,6 +2284,15 @@ class MessageDetailsCompanion extends UpdateCompanion<MessageDetail> {
     if (receivedAt.present) {
       map['received_at'] = Variable<DateTime>(receivedAt.value);
     }
+    if (messageIdHeader.present) {
+      map['message_id_header'] = Variable<String>(messageIdHeader.value);
+    }
+    if (inReplyToHeader.present) {
+      map['in_reply_to_header'] = Variable<String>(inReplyToHeader.value);
+    }
+    if (referencesHeader.present) {
+      map['references_header'] = Variable<String>(referencesHeader.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -2094,12 +2304,16 @@ class MessageDetailsCompanion extends UpdateCompanion<MessageDetail> {
     return (StringBuffer('MessageDetailsCompanion(')
           ..write('id: $id, ')
           ..write('accountId: $accountId, ')
+          ..write('folderId: $folderId, ')
           ..write('subject: $subject, ')
           ..write('sender: $sender, ')
           ..write('recipients: $recipients, ')
           ..write('bodyPlain: $bodyPlain, ')
           ..write('bodyHtml: $bodyHtml, ')
           ..write('receivedAt: $receivedAt, ')
+          ..write('messageIdHeader: $messageIdHeader, ')
+          ..write('inReplyToHeader: $inReplyToHeader, ')
+          ..write('referencesHeader: $referencesHeader, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -3398,24 +3612,32 @@ typedef $$MessageDetailsTableCreateCompanionBuilder =
     MessageDetailsCompanion Function({
       required String id,
       Value<String> accountId,
+      Value<String> folderId,
       required String subject,
       required String sender,
       required String recipients,
       required String bodyPlain,
       Value<String?> bodyHtml,
       required DateTime receivedAt,
+      Value<String?> messageIdHeader,
+      Value<String?> inReplyToHeader,
+      Value<String?> referencesHeader,
       Value<int> rowid,
     });
 typedef $$MessageDetailsTableUpdateCompanionBuilder =
     MessageDetailsCompanion Function({
       Value<String> id,
       Value<String> accountId,
+      Value<String> folderId,
       Value<String> subject,
       Value<String> sender,
       Value<String> recipients,
       Value<String> bodyPlain,
       Value<String?> bodyHtml,
       Value<DateTime> receivedAt,
+      Value<String?> messageIdHeader,
+      Value<String?> inReplyToHeader,
+      Value<String?> referencesHeader,
       Value<int> rowid,
     });
 
@@ -3435,6 +3657,11 @@ class $$MessageDetailsTableFilterComposer
 
   ColumnFilters<String> get accountId => $composableBuilder(
     column: $table.accountId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get folderId => $composableBuilder(
+    column: $table.folderId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -3467,6 +3694,21 @@ class $$MessageDetailsTableFilterComposer
     column: $table.receivedAt,
     builder: (column) => ColumnFilters(column),
   );
+
+  ColumnFilters<String> get messageIdHeader => $composableBuilder(
+    column: $table.messageIdHeader,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get inReplyToHeader => $composableBuilder(
+    column: $table.inReplyToHeader,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get referencesHeader => $composableBuilder(
+    column: $table.referencesHeader,
+    builder: (column) => ColumnFilters(column),
+  );
 }
 
 class $$MessageDetailsTableOrderingComposer
@@ -3485,6 +3727,11 @@ class $$MessageDetailsTableOrderingComposer
 
   ColumnOrderings<String> get accountId => $composableBuilder(
     column: $table.accountId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get folderId => $composableBuilder(
+    column: $table.folderId,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -3517,6 +3764,21 @@ class $$MessageDetailsTableOrderingComposer
     column: $table.receivedAt,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get messageIdHeader => $composableBuilder(
+    column: $table.messageIdHeader,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get inReplyToHeader => $composableBuilder(
+    column: $table.inReplyToHeader,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get referencesHeader => $composableBuilder(
+    column: $table.referencesHeader,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$MessageDetailsTableAnnotationComposer
@@ -3533,6 +3795,9 @@ class $$MessageDetailsTableAnnotationComposer
 
   GeneratedColumn<String> get accountId =>
       $composableBuilder(column: $table.accountId, builder: (column) => column);
+
+  GeneratedColumn<String> get folderId =>
+      $composableBuilder(column: $table.folderId, builder: (column) => column);
 
   GeneratedColumn<String> get subject =>
       $composableBuilder(column: $table.subject, builder: (column) => column);
@@ -3553,6 +3818,21 @@ class $$MessageDetailsTableAnnotationComposer
 
   GeneratedColumn<DateTime> get receivedAt => $composableBuilder(
     column: $table.receivedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get messageIdHeader => $composableBuilder(
+    column: $table.messageIdHeader,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get inReplyToHeader => $composableBuilder(
+    column: $table.inReplyToHeader,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get referencesHeader => $composableBuilder(
+    column: $table.referencesHeader,
     builder: (column) => column,
   );
 }
@@ -3592,44 +3872,60 @@ class $$MessageDetailsTableTableManager
               ({
                 Value<String> id = const Value.absent(),
                 Value<String> accountId = const Value.absent(),
+                Value<String> folderId = const Value.absent(),
                 Value<String> subject = const Value.absent(),
                 Value<String> sender = const Value.absent(),
                 Value<String> recipients = const Value.absent(),
                 Value<String> bodyPlain = const Value.absent(),
                 Value<String?> bodyHtml = const Value.absent(),
                 Value<DateTime> receivedAt = const Value.absent(),
+                Value<String?> messageIdHeader = const Value.absent(),
+                Value<String?> inReplyToHeader = const Value.absent(),
+                Value<String?> referencesHeader = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => MessageDetailsCompanion(
                 id: id,
                 accountId: accountId,
+                folderId: folderId,
                 subject: subject,
                 sender: sender,
                 recipients: recipients,
                 bodyPlain: bodyPlain,
                 bodyHtml: bodyHtml,
                 receivedAt: receivedAt,
+                messageIdHeader: messageIdHeader,
+                inReplyToHeader: inReplyToHeader,
+                referencesHeader: referencesHeader,
                 rowid: rowid,
               ),
           createCompanionCallback:
               ({
                 required String id,
                 Value<String> accountId = const Value.absent(),
+                Value<String> folderId = const Value.absent(),
                 required String subject,
                 required String sender,
                 required String recipients,
                 required String bodyPlain,
                 Value<String?> bodyHtml = const Value.absent(),
                 required DateTime receivedAt,
+                Value<String?> messageIdHeader = const Value.absent(),
+                Value<String?> inReplyToHeader = const Value.absent(),
+                Value<String?> referencesHeader = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => MessageDetailsCompanion.insert(
                 id: id,
                 accountId: accountId,
+                folderId: folderId,
                 subject: subject,
                 sender: sender,
                 recipients: recipients,
                 bodyPlain: bodyPlain,
                 bodyHtml: bodyHtml,
                 receivedAt: receivedAt,
+                messageIdHeader: messageIdHeader,
+                inReplyToHeader: inReplyToHeader,
+                referencesHeader: referencesHeader,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/lib/features/compose/data/compose_repository_impl.dart
+++ b/lib/features/compose/data/compose_repository_impl.dart
@@ -7,6 +7,7 @@ import '../../../core/result/result.dart';
 import '../../../data/local/app_database.dart';
 import '../../../data/secure/secure_storage_service.dart';
 import '../domain/entities/outgoing_message.dart';
+import '../domain/entities/reply_context.dart';
 import '../domain/repositories/compose_repository.dart';
 
 class ComposeRepositoryImpl implements ComposeRepository {
@@ -64,13 +65,18 @@ class ComposeRepositoryImpl implements ComposeRepository {
         bcc: message.bcc.map((email) => MailAddress(null, email)).toList(),
         subject: message.subject,
       );
+      _applyReplyHeaders(mimeMessage, message);
       await smtpClient.sendMessage(mimeMessage);
       await _appendToSentFolder(
         account: account,
         password: password,
         mimeMessage: mimeMessage,
       );
-      await _cacheSentMessage(account: account, message: message);
+      await _cacheSentMessage(
+        account: account,
+        message: message,
+        mimeMessage: mimeMessage,
+      );
 
       _logger.i(
         'Sent SMTP message to ${message.to.join(', ')} from ${message.accountId}',
@@ -140,6 +146,7 @@ class ComposeRepositoryImpl implements ComposeRepository {
   Future<void> _cacheSentMessage({
     required Account account,
     required OutgoingMessage message,
+    required MimeMessage mimeMessage,
   }) async {
     final sentPath = await _sentFolderPath(account.id);
     final sentFolderId = _folderId(account.id, sentPath);
@@ -171,6 +178,10 @@ class ComposeRepositoryImpl implements ComposeRepository {
           bodyPlain: message.body,
           bodyHtml: const Value(null),
           receivedAt: sentAt,
+          folderId: Value(sentFolderId),
+          messageIdHeader: Value(mimeMessage.getHeaderValue('Message-Id')),
+          inReplyToHeader: Value(mimeMessage.getHeaderValue('In-Reply-To')),
+          referencesHeader: Value(mimeMessage.getHeaderValue('References')),
         ),
         mode: InsertMode.insertOrReplace,
       );
@@ -191,6 +202,28 @@ class ComposeRepositoryImpl implements ComposeRepository {
         mode: InsertMode.insertOrReplace,
       );
     });
+  }
+
+  void _applyReplyHeaders(MimeMessage mimeMessage, OutgoingMessage message) {
+    final context = message.replyContext;
+    if (context == null || context.action == ReplyAction.forward) {
+      return;
+    }
+
+    final originalMessageId = context.originalMessageIdHeader?.trim();
+    if (originalMessageId == null || originalMessageId.isEmpty) {
+      return;
+    }
+
+    mimeMessage.setHeader('In-Reply-To', originalMessageId);
+    final references = [
+      ...?context.originalReferencesHeader
+          ?.split(RegExp(r'\s+'))
+          .map((value) => value.trim())
+          .where((value) => value.isNotEmpty),
+      originalMessageId,
+    ];
+    mimeMessage.setHeader('References', references.toSet().join(' '));
   }
 
   String _folderId(String accountId, String path) {

--- a/lib/features/compose/domain/entities/reply_context.dart
+++ b/lib/features/compose/domain/entities/reply_context.dart
@@ -3,13 +3,25 @@ enum ReplyAction { reply, replyAll, forward }
 class ReplyContext {
   const ReplyContext({
     required this.messageId,
+    required this.targetMessageId,
     required this.subject,
     required this.action,
     required this.recipients,
+    required this.originalSender,
+    required this.originalReceivedAt,
+    required this.originalBody,
+    this.originalMessageIdHeader,
+    this.originalReferencesHeader,
   });
 
   final String messageId;
+  final String targetMessageId;
   final String subject;
   final ReplyAction action;
   final List<String> recipients;
+  final String originalSender;
+  final DateTime originalReceivedAt;
+  final String originalBody;
+  final String? originalMessageIdHeader;
+  final String? originalReferencesHeader;
 }

--- a/lib/features/compose/presentation/compose_screen.dart
+++ b/lib/features/compose/presentation/compose_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
 import '../../attachments/domain/entities/attachment_ref.dart';
 import '../../auth/presentation/auth_controller.dart';
@@ -38,7 +39,7 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
   final _ccController = TextEditingController();
   final _bccController = TextEditingController();
   late final TextEditingController _subjectController;
-  final _bodyController = TextEditingController();
+  late final TextEditingController _bodyController;
 
   bool _showCcBcc = false;
 
@@ -52,6 +53,11 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
       text: widget.replyContext == null
           ? ''
           : '${_prefixFor(widget.replyContext!.action)}${widget.replyContext!.subject}',
+    );
+    _bodyController = TextEditingController(
+      text: widget.replyContext == null
+          ? ''
+          : '\n\n${_quotedTextFor(widget.replyContext!)}',
     );
   }
 
@@ -70,6 +76,24 @@ class _ComposeScreenState extends ConsumerState<ComposeScreen> {
       ReplyAction.reply || ReplyAction.replyAll => 'Re: ',
       ReplyAction.forward => 'Fwd: ',
     };
+  }
+
+  String _quotedTextFor(ReplyContext context) {
+    final formattedDate = DateFormat(
+      'EEE, MMM d, y HH:mm',
+    ).format(context.originalReceivedAt);
+    final header = switch (context.action) {
+      ReplyAction.reply || ReplyAction.replyAll =>
+        'On $formattedDate ${context.originalSender} wrote:',
+      ReplyAction.forward =>
+        '---------- Forwarded message ----------\nFrom: ${context.originalSender}\nDate: $formattedDate\nSubject: ${context.subject}',
+    };
+    final quotedBody = context.originalBody
+        .replaceAll('\r\n', '\n')
+        .split('\n')
+        .map((line) => '> $line')
+        .join('\n');
+    return '$header\n$quotedBody';
   }
 
   Future<void> _send() async {

--- a/lib/features/mailbox/data/mailbox_repository_impl.dart
+++ b/lib/features/mailbox/data/mailbox_repository_impl.dart
@@ -6,6 +6,7 @@ import '../../../data/secure/secure_storage_service.dart';
 import '../domain/entities/mail_folder.dart' as domain;
 import '../domain/entities/mail_message_detail.dart';
 import '../domain/entities/mail_message_summary.dart';
+import '../domain/entities/mail_thread.dart';
 import '../domain/repositories/mailbox_repository.dart';
 
 class MailboxRepositoryImpl implements MailboxRepository {
@@ -269,13 +270,29 @@ class MailboxRepositoryImpl implements MailboxRepository {
         id: cached.id,
         subject: cached.subject,
         sender: cached.sender,
-        recipients: cached.recipients.split(','),
+        recipients: _splitRecipients(cached.recipients),
         bodyPlain: cached.bodyPlain,
         bodyHtml: cached.bodyHtml,
         receivedAt: cached.receivedAt,
       );
     }
 
+    final cachedFallback = await _cacheFallbackDetail(accountId, id);
+    return MailMessageDetail(
+      id: cachedFallback.id,
+      subject: cachedFallback.subject,
+      sender: cachedFallback.sender,
+      recipients: _splitRecipients(cachedFallback.recipients),
+      bodyPlain: cachedFallback.bodyPlain,
+      bodyHtml: cachedFallback.bodyHtml,
+      receivedAt: cachedFallback.receivedAt,
+    );
+  }
+
+  Future<db.MessageDetail> _cacheFallbackDetail(
+    String accountId,
+    String id,
+  ) async {
     final summary = _seedMessages(
       accountId,
     ).firstWhere((message) => message.id == id);
@@ -296,6 +313,7 @@ class MailboxRepositoryImpl implements MailboxRepository {
           db.MessageDetailsCompanion.insert(
             id: detail.id,
             accountId: Value(accountId),
+            folderId: Value(summary.folderId),
             subject: detail.subject,
             sender: detail.sender,
             recipients: detail.recipients.join(','),
@@ -305,7 +323,98 @@ class MailboxRepositoryImpl implements MailboxRepository {
           ),
         );
 
-    return detail;
+    return (await (_appDatabase.select(_appDatabase.messageDetails)..where(
+          (table) => table.id.equals(id) & table.accountId.equals(accountId),
+        ))
+        .getSingle());
+  }
+
+  @override
+  Future<MailThread> getMessageThread({
+    required String accountId,
+    required String messageId,
+  }) async {
+    var selected =
+        await (_appDatabase.select(_appDatabase.messageDetails)..where(
+              (table) =>
+                  table.id.equals(messageId) &
+                  table.accountId.equals(accountId),
+            ))
+            .getSingleOrNull();
+
+    selected ??= await _cacheFallbackDetail(accountId, messageId);
+
+    await _syncSentMessagesForThread(accountId, selected);
+
+    final allDetails = await (_appDatabase.select(
+      _appDatabase.messageDetails,
+    )..where((table) => table.accountId.equals(accountId))).get();
+    final folders = await _cachedFolders(accountId);
+    final folderNames = {
+      for (final folder in folders) folder.id: _folderLabel(folder),
+    };
+
+    final selectedMessage = selected;
+    final selectedTokens = _threadHeaderTokens(selectedMessage);
+    var threadRows = selectedTokens.isEmpty
+        ? <db.MessageDetail>[]
+        : allDetails
+              .where(
+                (row) =>
+                    row.id == selectedMessage.id ||
+                    _threadHeaderTokens(
+                      row,
+                    ).any((token) => selectedTokens.contains(token)),
+              )
+              .toList();
+
+    if (threadRows.length <= 1) {
+      final normalizedSubject = _normalizeThreadSubject(
+        selectedMessage.subject,
+      );
+      threadRows = allDetails
+          .where(
+            (row) => _normalizeThreadSubject(row.subject) == normalizedSubject,
+          )
+          .toList();
+    }
+
+    threadRows.sort(
+      (left, right) => left.receivedAt.compareTo(right.receivedAt),
+    );
+    return MailThread(
+      subject: selectedMessage.subject,
+      selectedMessageId: selectedMessage.id,
+      messages: threadRows
+          .map((row) => _threadMessageFromRow(row, folderNames))
+          .toList(),
+    );
+  }
+
+  Future<void> _syncSentMessagesForThread(
+    String accountId,
+    db.MessageDetail selected,
+  ) async {
+    final secureStorageService = _secureStorageService;
+    if (secureStorageService == null) {
+      return;
+    }
+
+    final threadSubject = _normalizeThreadSubject(selected.subject);
+    if (threadSubject.isEmpty || threadSubject == '(no subject)') {
+      return;
+    }
+
+    final folders = await getFolders(accountId);
+    final sentFolders = folders.where(_isSentFolder).toList();
+    for (final folder in sentFolders) {
+      await _searchRemoteMessages(
+        accountId: accountId,
+        folder: folder,
+        query: threadSubject,
+        limit: 30,
+      );
+    }
   }
 
   @override
@@ -504,12 +613,16 @@ class MailboxRepositoryImpl implements MailboxRepository {
         db.MessageDetailsCompanion.insert(
           id: messageId,
           accountId: Value(accountId),
+          folderId: Value(folder.id),
           subject: subject,
           sender: sender,
           recipients: recipients.join(','),
           bodyPlain: bodyPlain,
           bodyHtml: Value(bodyHtml),
           receivedAt: receivedAt,
+          messageIdHeader: Value(message.getHeaderValue('Message-ID')),
+          inReplyToHeader: Value(message.getHeaderValue('In-Reply-To')),
+          referencesHeader: Value(message.getHeaderValue('References')),
         ),
       );
 
@@ -564,6 +677,84 @@ class MailboxRepositoryImpl implements MailboxRepository {
       hasAttachments: row.hasAttachments,
       sequence: row.sequence,
     );
+  }
+
+  MailThreadMessage _threadMessageFromRow(
+    db.MessageDetail row,
+    Map<String, String> folderNames,
+  ) {
+    final fallbackFolder = row.folderId.isEmpty ? 'Mail' : row.folderId;
+    return MailThreadMessage(
+      id: row.id,
+      folderId: row.folderId,
+      folderName: folderNames[row.folderId] ?? fallbackFolder,
+      subject: row.subject,
+      sender: row.sender,
+      recipients: _splitRecipients(row.recipients),
+      bodyPlain: row.bodyPlain,
+      bodyHtml: row.bodyHtml,
+      receivedAt: row.receivedAt,
+      messageIdHeader: row.messageIdHeader,
+      inReplyToHeader: row.inReplyToHeader,
+      referencesHeader: row.referencesHeader,
+    );
+  }
+
+  Set<String> _threadHeaderTokens(db.MessageDetail row) {
+    return {
+      ..._messageIdTokens(row.messageIdHeader),
+      ..._messageIdTokens(row.inReplyToHeader),
+      ..._messageIdTokens(row.referencesHeader),
+    };
+  }
+
+  Set<String> _messageIdTokens(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return const {};
+    }
+
+    final matches = RegExp(r'<[^>]+>|[^\s]+').allMatches(raw);
+    return matches
+        .map((match) => match.group(0)?.trim())
+        .whereType<String>()
+        .map((value) => value.toLowerCase())
+        .where((value) => value.isNotEmpty)
+        .toSet();
+  }
+
+  String _normalizeThreadSubject(String subject) {
+    var normalized = subject.trim().toLowerCase();
+    var previous = '';
+    final prefixPattern = RegExp(r'^(re|fw|fwd):\s*', caseSensitive: false);
+    while (normalized != previous) {
+      previous = normalized;
+      normalized = normalized.replaceFirst(prefixPattern, '').trim();
+    }
+    return normalized.isEmpty ? '(no subject)' : normalized;
+  }
+
+  List<String> _splitRecipients(String recipients) {
+    return recipients
+        .split(',')
+        .map((recipient) => recipient.trim())
+        .where((recipient) => recipient.isNotEmpty)
+        .toList();
+  }
+
+  String _folderLabel(domain.MailFolder folder) {
+    return folder.name.trim().isEmpty ? folder.path : folder.name;
+  }
+
+  bool _isSentFolder(domain.MailFolder folder) {
+    final normalizedPath = folder.path.trim().toLowerCase();
+    final normalizedName = folder.name.trim().toLowerCase();
+    return normalizedPath == 'sent' ||
+        normalizedName == 'sent' ||
+        normalizedPath.contains('sent mail') ||
+        normalizedName.contains('sent mail') ||
+        normalizedPath.contains('/sent') ||
+        normalizedName.contains('poslano') ||
+        normalizedPath.contains('poslano');
   }
 
   String _messageId(

--- a/lib/features/mailbox/domain/entities/mail_thread.dart
+++ b/lib/features/mailbox/domain/entities/mail_thread.dart
@@ -1,0 +1,85 @@
+class MailThread {
+  const MailThread({
+    required this.subject,
+    required this.selectedMessageId,
+    required this.messages,
+  });
+
+  final String subject;
+  final String selectedMessageId;
+  final List<MailThreadMessage> messages;
+}
+
+class MailThreadMessage {
+  const MailThreadMessage({
+    required this.id,
+    required this.folderId,
+    required this.folderName,
+    required this.subject,
+    required this.sender,
+    required this.recipients,
+    required this.bodyPlain,
+    required this.bodyHtml,
+    required this.receivedAt,
+    required this.messageIdHeader,
+    required this.inReplyToHeader,
+    required this.referencesHeader,
+  });
+
+  final String id;
+  final String folderId;
+  final String folderName;
+  final String subject;
+  final String sender;
+  final List<String> recipients;
+  final String bodyPlain;
+  final String? bodyHtml;
+  final DateTime receivedAt;
+  final String? messageIdHeader;
+  final String? inReplyToHeader;
+  final String? referencesHeader;
+
+  String get visibleBody => splitQuotedText(bodyPlain).visibleBody;
+
+  String? get quotedBody => splitQuotedText(bodyPlain).quotedBody;
+}
+
+class QuotedTextParts {
+  const QuotedTextParts({required this.visibleBody, required this.quotedBody});
+
+  final String visibleBody;
+  final String? quotedBody;
+}
+
+QuotedTextParts splitQuotedText(String body) {
+  final normalized = body.replaceAll('\r\n', '\n');
+  final quotePatterns = [
+    RegExp(r'\nOn .+ wrote:\s*\n', caseSensitive: false),
+    RegExp(r'\nDana .+ napisao/la je:\s*\n', caseSensitive: false),
+    RegExp(r'\n-+\s*Original Message\s*-+\s*\n', caseSensitive: false),
+    RegExp(r'\n-+\s*Forwarded message\s*-+\s*\n', caseSensitive: false),
+    RegExp(r'\n>{1,2}\s?'),
+  ];
+
+  int? quoteIndex;
+  for (final pattern in quotePatterns) {
+    final match = pattern.firstMatch(normalized);
+    if (match == null) {
+      continue;
+    }
+    if (quoteIndex == null || match.start < quoteIndex) {
+      quoteIndex = match.start;
+    }
+  }
+
+  if (quoteIndex == null) {
+    return QuotedTextParts(visibleBody: normalized.trim(), quotedBody: null);
+  }
+
+  final visible = normalized.substring(0, quoteIndex).trim();
+  final quoted = normalized.substring(quoteIndex).trim();
+  return QuotedTextParts(
+    visibleBody: visible.isEmpty ? normalized.trim() : visible,
+    quotedBody: quoted.isEmpty ? null : quoted,
+  );
+}

--- a/lib/features/mailbox/domain/repositories/mailbox_repository.dart
+++ b/lib/features/mailbox/domain/repositories/mailbox_repository.dart
@@ -1,6 +1,7 @@
 import '../entities/mail_folder.dart';
 import '../entities/mail_message_detail.dart';
 import '../entities/mail_message_summary.dart';
+import '../entities/mail_thread.dart';
 
 abstract class MailboxRepository {
   Future<List<MailFolder>> getFolders(String accountId);
@@ -23,6 +24,11 @@ abstract class MailboxRepository {
   Future<MailMessageDetail> getMessageDetail({
     required String accountId,
     required String id,
+  });
+
+  Future<MailThread> getMessageThread({
+    required String accountId,
+    required String messageId,
   });
 
   Future<List<MailMessageSummary>> searchMessages({

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -5,6 +5,7 @@ import '../../auth/presentation/auth_controller.dart';
 import '../domain/entities/mail_folder.dart';
 import '../domain/entities/mail_message_detail.dart';
 import '../domain/entities/mail_message_summary.dart';
+import '../domain/entities/mail_thread.dart';
 
 final foldersProvider = FutureProvider<List<MailFolder>>((ref) {
   final account = ref.watch(activeAccountProvider).asData?.value;
@@ -25,6 +26,19 @@ final messageDetailProvider = FutureProvider.family<MailMessageDetail, String>((
   return ref
       .watch(mailboxRepositoryProvider)
       .getMessageDetail(accountId: account.id, id: messageId);
+});
+
+final messageThreadProvider = FutureProvider.family<MailThread, String>((
+  ref,
+  messageId,
+) {
+  final account = ref.watch(activeAccountProvider).asData?.value;
+  if (account == null) {
+    throw StateError('No active account selected.');
+  }
+  return ref
+      .watch(mailboxRepositoryProvider)
+      .getMessageThread(accountId: account.id, messageId: messageId);
 });
 
 final folderMessagesProvider = FutureProvider.autoDispose

--- a/lib/features/mailbox/presentation/message_detail_screen.dart
+++ b/lib/features/mailbox/presentation/message_detail_screen.dart
@@ -6,21 +6,30 @@ import 'package:intl/intl.dart';
 import '../../../app/router/app_route.dart';
 import '../../../core/widgets/state_views.dart';
 import '../../compose/domain/entities/reply_context.dart';
-import '../domain/entities/mail_message_detail.dart';
+import '../domain/entities/mail_thread.dart';
 import 'mailbox_controller.dart';
 
 const _screenBackground = Color(0xFFF7F8FC);
-const _primary = Color(0xFF153B52);
 const _mutedText = Color(0xFF5D636B);
 
-class MessageDetailScreen extends ConsumerWidget {
+class MessageDetailScreen extends ConsumerStatefulWidget {
   const MessageDetailScreen({super.key, required this.messageId});
 
   final String messageId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final messageAsync = ref.watch(messageDetailProvider(messageId));
+  ConsumerState<MessageDetailScreen> createState() =>
+      _MessageDetailScreenState();
+}
+
+class _MessageDetailScreenState extends ConsumerState<MessageDetailScreen> {
+  final _expandedMessageIds = <String>{};
+  final _visibleQuotedMessageIds = <String>{};
+  String? _initializedThreadMessageId;
+
+  @override
+  Widget build(BuildContext context) {
+    final threadAsync = ref.watch(messageThreadProvider(widget.messageId));
 
     return Scaffold(
       backgroundColor: _screenBackground,
@@ -37,8 +46,29 @@ class MessageDetailScreen extends ConsumerWidget {
               },
             ),
             Expanded(
-              child: messageAsync.when(
-                data: (message) => _MessageDetailContent(message: message),
+              child: threadAsync.when(
+                data: (thread) {
+                  _ensureDefaultExpansion(thread);
+                  return _MessageThreadContent(
+                    thread: thread,
+                    expandedMessageIds: _expandedMessageIds,
+                    visibleQuotedMessageIds: _visibleQuotedMessageIds,
+                    onToggleExpanded: _toggleExpanded,
+                    onToggleQuoted: _toggleQuoted,
+                    onReply: (message) => _openCompose(
+                      context: context,
+                      thread: thread,
+                      message: message,
+                      action: ReplyAction.reply,
+                    ),
+                    onForward: (message) => _openCompose(
+                      context: context,
+                      thread: thread,
+                      message: message,
+                      action: ReplyAction.forward,
+                    ),
+                  );
+                },
                 error: (error, stackTrace) =>
                     ErrorStateView(message: error.toString()),
                 loading: () => const Center(child: CircularProgressIndicator()),
@@ -46,6 +76,63 @@ class MessageDetailScreen extends ConsumerWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  void _ensureDefaultExpansion(MailThread thread) {
+    if (_initializedThreadMessageId == thread.selectedMessageId) {
+      return;
+    }
+
+    _initializedThreadMessageId = thread.selectedMessageId;
+    _expandedMessageIds
+      ..clear()
+      ..add(thread.selectedMessageId);
+    if (thread.messages.isNotEmpty) {
+      _expandedMessageIds.add(thread.messages.last.id);
+    }
+    _visibleQuotedMessageIds.clear();
+  }
+
+  void _toggleExpanded(String messageId) {
+    setState(() {
+      if (!_expandedMessageIds.add(messageId)) {
+        _expandedMessageIds.remove(messageId);
+      }
+    });
+  }
+
+  void _toggleQuoted(String messageId) {
+    setState(() {
+      if (!_visibleQuotedMessageIds.add(messageId)) {
+        _visibleQuotedMessageIds.remove(messageId);
+      }
+    });
+  }
+
+  void _openCompose({
+    required BuildContext context,
+    required MailThread thread,
+    required MailThreadMessage message,
+    required ReplyAction action,
+  }) {
+    context.push(
+      AppRoute.compose.path,
+      extra: ReplyContext(
+        messageId: thread.selectedMessageId,
+        targetMessageId: message.id,
+        subject: thread.subject,
+        action: action,
+        recipients: switch (action) {
+          ReplyAction.reply || ReplyAction.replyAll => [message.sender],
+          ReplyAction.forward => const [],
+        },
+        originalSender: message.sender,
+        originalReceivedAt: message.receivedAt,
+        originalBody: message.visibleBody,
+        originalMessageIdHeader: message.messageIdHeader,
+        originalReferencesHeader: message.referencesHeader,
       ),
     );
   }
@@ -58,10 +145,8 @@ class _MessageTopBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
     return Padding(
-      padding: const EdgeInsets.fromLTRB(14, 10, 14, 8),
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 4),
       child: Row(
         children: [
           IconButton(
@@ -69,18 +154,26 @@ class _MessageTopBar extends StatelessWidget {
             onPressed: onBack,
             icon: const Icon(Icons.arrow_back, color: Color(0xFF202124)),
           ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              'Message',
-              style: textTheme.headlineMedium?.copyWith(
-                fontFamily: textTheme.bodyLarge?.fontFamily,
-                color: const Color(0xFF202124),
-                fontSize: 28,
-                fontWeight: FontWeight.w500,
-                letterSpacing: .2,
-              ),
-            ),
+          const Spacer(),
+          IconButton(
+            tooltip: 'Archive',
+            onPressed: () {},
+            icon: const Icon(Icons.archive_outlined),
+          ),
+          IconButton(
+            tooltip: 'Delete',
+            onPressed: () {},
+            icon: const Icon(Icons.delete_outline),
+          ),
+          IconButton(
+            tooltip: 'Mark unread',
+            onPressed: () {},
+            icon: const Icon(Icons.mark_email_unread_outlined),
+          ),
+          IconButton(
+            tooltip: 'More options',
+            onPressed: () {},
+            icon: const Icon(Icons.more_vert),
           ),
         ],
       ),
@@ -88,221 +181,301 @@ class _MessageTopBar extends StatelessWidget {
   }
 }
 
-class _MessageDetailContent extends StatelessWidget {
-  const _MessageDetailContent({required this.message});
+class _MessageThreadContent extends StatelessWidget {
+  const _MessageThreadContent({
+    required this.thread,
+    required this.expandedMessageIds,
+    required this.visibleQuotedMessageIds,
+    required this.onToggleExpanded,
+    required this.onToggleQuoted,
+    required this.onReply,
+    required this.onForward,
+  });
 
-  final MailMessageDetail message;
+  final MailThread thread;
+  final Set<String> expandedMessageIds;
+  final Set<String> visibleQuotedMessageIds;
+  final ValueChanged<String> onToggleExpanded;
+  final ValueChanged<String> onToggleQuoted;
+  final ValueChanged<MailThreadMessage> onReply;
+  final ValueChanged<MailThreadMessage> onForward;
 
   @override
   Widget build(BuildContext context) {
+    final selectedFolder = _selectedFolderName(thread);
+
     return ListView(
-      padding: const EdgeInsets.fromLTRB(24, 18, 24, 32),
+      padding: const EdgeInsets.fromLTRB(18, 12, 18, 32),
       children: [
-        _MessageCard(child: _MessageHeader(message: message)),
-        const SizedBox(height: 16),
-        _MessageCard(child: _MessageBody(body: message.bodyPlain)),
+        _SubjectHeader(subject: thread.subject, folderName: selectedFolder),
         const SizedBox(height: 18),
-        _ReplyActions(message: message),
-      ],
-    );
-  }
-}
-
-class _MessageCard extends StatelessWidget {
-  const _MessageCard({required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(26),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(22, 22, 22, 22),
-        child: child,
-      ),
-    );
-  }
-}
-
-class _MessageHeader extends StatelessWidget {
-  const _MessageHeader({required this.message});
-
-  final MailMessageDetail message;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          message.subject,
-          style: textTheme.titleLarge?.copyWith(
-            color: _primary,
-            fontSize: 20,
-            fontWeight: FontWeight.w600,
-            height: 1.2,
-            letterSpacing: .1,
+        for (final message in thread.messages) ...[
+          _ThreadMessageCard(
+            message: message,
+            isExpanded: expandedMessageIds.contains(message.id),
+            isQuotedVisible: visibleQuotedMessageIds.contains(message.id),
+            onToggleExpanded: () => onToggleExpanded(message.id),
+            onToggleQuoted: () => onToggleQuoted(message.id),
+            onReply: () => onReply(message),
+            onForward: () => onForward(message),
           ),
-        ),
-        const SizedBox(height: 16),
-        _MetaLine(label: 'From', value: message.sender),
-        const SizedBox(height: 8),
-        _MetaLine(label: 'To', value: message.recipients.join(', ')),
-        const SizedBox(height: 8),
-        Text(
-          DateFormat('MMM d, y HH:mm').format(message.receivedAt),
-          style: textTheme.bodyMedium?.copyWith(
-            color: _mutedText,
-            fontSize: 14,
-            height: 1.35,
-            letterSpacing: .1,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _MetaLine extends StatelessWidget {
-  const _MetaLine({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return RichText(
-      text: TextSpan(
-        style: textTheme.bodyMedium?.copyWith(
-          color: const Color(0xFF202124),
-          fontSize: 14,
-          height: 1.35,
-          letterSpacing: .1,
-        ),
-        children: [
-          TextSpan(
-            text: '$label: ',
-            style: const TextStyle(fontWeight: FontWeight.w600),
-          ),
-          TextSpan(
-            text: value,
-            style: const TextStyle(color: _mutedText),
-          ),
+          const SizedBox(height: 8),
         ],
-      ),
+      ],
     );
+  }
+
+  String? _selectedFolderName(MailThread thread) {
+    for (final message in thread.messages) {
+      if (message.id == thread.selectedMessageId) {
+        return message.folderName;
+      }
+    }
+    return null;
   }
 }
 
-class _MessageBody extends StatelessWidget {
-  const _MessageBody({required this.body});
+class _SubjectHeader extends StatelessWidget {
+  const _SubjectHeader({required this.subject, required this.folderName});
 
-  final String body;
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      body,
-      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-        color: const Color(0xFF202124),
-        fontSize: 15,
-        height: 1.5,
-        letterSpacing: .1,
-      ),
-    );
-  }
-}
-
-class _ReplyActions extends StatelessWidget {
-  const _ReplyActions({required this.message});
-
-  final MailMessageDetail message;
+  final String subject;
+  final String? folderName;
 
   @override
   Widget build(BuildContext context) {
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Expanded(
-          child: _ReplyButton(
-            icon: Icons.reply_outlined,
-            label: 'Reply',
-            onPressed: () => _openCompose(context, ReplyAction.reply),
+          child: Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              Text(
+                subject,
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  color: const Color(0xFF202124),
+                  fontSize: 30,
+                  fontWeight: FontWeight.w500,
+                  height: 1.15,
+                  letterSpacing: 0,
+                ),
+              ),
+              if (folderName != null)
+                Chip(
+                  visualDensity: VisualDensity.compact,
+                  label: Text(folderName!),
+                  backgroundColor: const Color(0xFFFFD08A),
+                  side: BorderSide.none,
+                  labelStyle: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: const Color(0xFF5B3B00),
+                  ),
+                ),
+            ],
           ),
         ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: _ReplyButton(
-            icon: Icons.reply_all_outlined,
-            label: 'Reply all',
-            onPressed: () => _openCompose(context, ReplyAction.replyAll),
-          ),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: _ReplyButton(
-            icon: Icons.forward_to_inbox_outlined,
-            label: 'Forward',
-            onPressed: () => _openCompose(context, ReplyAction.forward),
-          ),
+        IconButton(
+          tooltip: 'Star',
+          onPressed: () {},
+          icon: const Icon(Icons.star_border, color: _mutedText),
         ),
       ],
     );
   }
-
-  void _openCompose(BuildContext context, ReplyAction action) {
-    context.push(
-      AppRoute.compose.path,
-      extra: ReplyContext(
-        messageId: message.id,
-        subject: message.subject,
-        action: action,
-        recipients: switch (action) {
-          ReplyAction.reply => [message.sender],
-          ReplyAction.replyAll => [message.sender, ...message.recipients],
-          ReplyAction.forward => const [],
-        },
-      ),
-    );
-  }
 }
 
-class _ReplyButton extends StatelessWidget {
-  const _ReplyButton({
-    required this.icon,
-    required this.label,
-    required this.onPressed,
+class _ThreadMessageCard extends StatelessWidget {
+  const _ThreadMessageCard({
+    required this.message,
+    required this.isExpanded,
+    required this.isQuotedVisible,
+    required this.onToggleExpanded,
+    required this.onToggleQuoted,
+    required this.onReply,
+    required this.onForward,
   });
 
-  final IconData icon;
-  final String label;
-  final VoidCallback onPressed;
+  final MailThreadMessage message;
+  final bool isExpanded;
+  final bool isQuotedVisible;
+  final VoidCallback onToggleExpanded;
+  final VoidCallback onToggleQuoted;
+  final VoidCallback onReply;
+  final VoidCallback onForward;
 
   @override
   Widget build(BuildContext context) {
-    return OutlinedButton.icon(
-      onPressed: onPressed,
-      style: OutlinedButton.styleFrom(
-        foregroundColor: _primary,
-        minimumSize: const Size(0, 40),
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        side: const BorderSide(color: _mutedText),
-        shape: const StadiumBorder(),
-        textStyle: Theme.of(context).textTheme.labelLarge?.copyWith(
-          fontSize: 13,
-          fontWeight: FontWeight.w500,
-          letterSpacing: .05,
+    final quotedBody = message.quotedBody;
+    final body = message.visibleBody.isEmpty
+        ? message.bodyPlain
+        : message.visibleBody;
+
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(18),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(18),
+        onTap: onToggleExpanded,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 14, 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _SenderAvatar(sender: message.sender),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Wrap(
+                          spacing: 8,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            Text(
+                              _senderLabel(message.sender),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.titleMedium
+                                  ?.copyWith(
+                                    color: const Color(0xFF202124),
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.w700,
+                                    letterSpacing: 0,
+                                  ),
+                            ),
+                            Text(
+                              DateFormat('h:mm a').format(message.receivedAt),
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: _mutedText,
+                                    fontSize: 14,
+                                    letterSpacing: 0,
+                                  ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'to ${message.recipients.join(', ')} · ${message.folderName}',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: _mutedText,
+                                fontSize: 15,
+                                letterSpacing: 0,
+                              ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: 'Reply',
+                    onPressed: onReply,
+                    icon: const Icon(Icons.reply, color: _mutedText),
+                  ),
+                  IconButton(
+                    tooltip: 'Forward',
+                    onPressed: onForward,
+                    icon: const Icon(Icons.forward, color: _mutedText),
+                  ),
+                  IconButton(
+                    tooltip: 'Message options',
+                    onPressed: () {},
+                    icon: const Icon(Icons.more_vert, color: _mutedText),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20),
+              Text(
+                body,
+                maxLines: isExpanded ? null : 2,
+                overflow: isExpanded
+                    ? TextOverflow.visible
+                    : TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: const Color(0xFF202124),
+                  fontSize: 16,
+                  height: 1.42,
+                  letterSpacing: 0,
+                ),
+              ),
+              if (isExpanded && quotedBody != null) ...[
+                const SizedBox(height: 12),
+                TextButton(
+                  onPressed: onToggleQuoted,
+                  style: TextButton.styleFrom(
+                    padding: EdgeInsets.zero,
+                    minimumSize: const Size(0, 36),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    alignment: Alignment.centerLeft,
+                  ),
+                  child: Text(
+                    isQuotedVisible ? 'Hide quoted text' : 'Show quoted text',
+                  ),
+                ),
+                if (isQuotedVisible) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    quotedBody,
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF202124),
+                      fontSize: 16,
+                      height: 1.42,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ],
+            ],
+          ),
         ),
       ),
-      icon: Icon(icon, size: 16),
-      label: FittedBox(fit: BoxFit.scaleDown, child: Text(label, maxLines: 1)),
+    );
+  }
+
+  String _senderLabel(String sender) {
+    final localPart = sender.split('@').first.trim();
+    if (localPart.isEmpty) {
+      return sender;
+    }
+    return localPart
+        .split(RegExp(r'[._-]+'))
+        .where((part) => part.isNotEmpty)
+        .map(
+          (part) =>
+              '${part.characters.first.toUpperCase()}${part.substring(1)}',
+        )
+        .join(' ');
+  }
+}
+
+class _SenderAvatar extends StatelessWidget {
+  const _SenderAvatar({required this.sender});
+
+  final String sender;
+
+  @override
+  Widget build(BuildContext context) {
+    final initial = sender.trim().isEmpty
+        ? '?'
+        : sender.trim().characters.first.toUpperCase();
+    return CircleAvatar(
+      radius: 28,
+      backgroundColor: const Color(0xFF47C4D6),
+      child: Text(
+        initial,
+        style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+          color: Colors.white,
+          fontSize: 28,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0,
+        ),
+      ),
     );
   }
 }

--- a/test/compose_screen_test.dart
+++ b/test/compose_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:finestar_mail/features/auth/domain/entities/connection_settings.
 import 'package:finestar_mail/features/auth/domain/entities/mail_account.dart';
 import 'package:finestar_mail/features/auth/presentation/auth_controller.dart';
 import 'package:finestar_mail/features/compose/domain/entities/outgoing_message.dart';
+import 'package:finestar_mail/features/compose/domain/entities/reply_context.dart';
 import 'package:finestar_mail/features/compose/domain/repositories/compose_repository.dart';
 import 'package:finestar_mail/features/compose/presentation/compose_controller.dart';
 import 'package:finestar_mail/features/compose/presentation/compose_screen.dart';
@@ -73,6 +74,25 @@ void main() {
     expect(find.text('Bcc'), findsOneWidget);
   });
 
+  testWidgets('reply context prefills recipients, subject, and quoted text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildTestApp(replyContext: _replyContext));
+    await tester.pumpAndSettle();
+
+    expect(find.text('client@finestar.hr'), findsOneWidget);
+    expect(find.text('Re: Project update'), findsOneWidget);
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is EditableText &&
+            widget.controller.text.contains('On Thu, Apr 16, 2026') &&
+            widget.controller.text.contains('> Original body'),
+      ),
+      findsOneWidget,
+    );
+  });
+
   test('compose controller adds, removes, and sends attachments', () async {
     final composeRepository = _FakeComposeRepository();
     final container = ProviderContainer(
@@ -105,16 +125,18 @@ void main() {
       bcc: const [],
       subject: 'Photo',
       body: 'Attached.',
+      replyContext: _replyContext,
     );
 
     expect(
       composeRepository.lastMessage?.attachments.single.fileName,
       'photo.jpg',
     );
+    expect(composeRepository.lastMessage?.replyContext?.targetMessageId, 'm1');
   });
 }
 
-Widget _buildTestApp() {
+Widget _buildTestApp({ReplyContext? replyContext}) {
   return ProviderScope(
     overrides: [
       activeAccountProvider.overrideWith((ref) async => _account),
@@ -123,7 +145,7 @@ Widget _buildTestApp() {
       ),
       composeRepositoryProvider.overrideWith((ref) => _FakeComposeRepository()),
     ],
-    child: const MaterialApp(home: ComposeScreen()),
+    child: MaterialApp(home: ComposeScreen(replyContext: replyContext)),
   );
 }
 
@@ -140,6 +162,19 @@ final _account = MailAccount(
     smtpSecurity: MailSecurity.sslTls,
   ),
   createdAt: DateTime(2026, 4, 16),
+);
+
+final _replyContext = ReplyContext(
+  messageId: 'thread-root',
+  targetMessageId: 'm1',
+  subject: 'Project update',
+  action: ReplyAction.reply,
+  recipients: const ['client@finestar.hr'],
+  originalSender: 'client@finestar.hr',
+  originalReceivedAt: DateTime(2026, 4, 16, 8, 30),
+  originalBody: 'Original body',
+  originalMessageIdHeader: '<m1@finestar.hr>',
+  originalReferencesHeader: '<root@finestar.hr>',
 );
 
 class _FakeAttachmentRepository implements AttachmentRepository {

--- a/test/mailbox_repository_test.dart
+++ b/test/mailbox_repository_test.dart
@@ -134,4 +134,183 @@ void main() {
 
     expect(messages, isEmpty);
   });
+
+  test('thread lookup includes cached messages from inbox and sent', () async {
+    final database = db.AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(database.close);
+
+    await _insertFolder(database, 'account:inbox', 'INBOX');
+    await _insertFolder(database, 'account:sent', 'Sent');
+    await _insertDetail(
+      database,
+      id: 'inbox-1',
+      accountId: 'account',
+      folderId: 'account:inbox',
+      subject: 'Project update',
+      sender: 'client@finestar.hr',
+      recipients: 'me@finestar.hr',
+      receivedAt: DateTime(2026, 4, 16, 8),
+    );
+    await _insertDetail(
+      database,
+      id: 'sent-1',
+      accountId: 'account',
+      folderId: 'account:sent',
+      subject: 'Re: Project update',
+      sender: 'me@finestar.hr',
+      recipients: 'client@finestar.hr',
+      receivedAt: DateTime(2026, 4, 16, 9),
+    );
+
+    final repository = MailboxRepositoryImpl(appDatabase: database);
+    final thread = await repository.getMessageThread(
+      accountId: 'account',
+      messageId: 'inbox-1',
+    );
+
+    expect(thread.messages.map((message) => message.id), ['inbox-1', 'sent-1']);
+    expect(thread.messages.map((message) => message.folderName), [
+      'INBOX',
+      'Sent',
+    ]);
+  });
+
+  test('thread lookup prefers RFC linkage over subject fallback', () async {
+    final database = db.AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(database.close);
+
+    await _insertFolder(database, 'account:inbox', 'INBOX');
+    await _insertDetail(
+      database,
+      id: 'root',
+      accountId: 'account',
+      folderId: 'account:inbox',
+      subject: 'Shared subject',
+      sender: 'one@finestar.hr',
+      recipients: 'me@finestar.hr',
+      receivedAt: DateTime(2026, 4, 16, 8),
+      messageIdHeader: '<root@finestar.hr>',
+    );
+    await _insertDetail(
+      database,
+      id: 'reply',
+      accountId: 'account',
+      folderId: 'account:inbox',
+      subject: 'Re: Shared subject',
+      sender: 'me@finestar.hr',
+      recipients: 'one@finestar.hr',
+      receivedAt: DateTime(2026, 4, 16, 9),
+      messageIdHeader: '<reply@finestar.hr>',
+      inReplyToHeader: '<root@finestar.hr>',
+      referencesHeader: '<root@finestar.hr>',
+    );
+    await _insertDetail(
+      database,
+      id: 'same-subject-unlinked',
+      accountId: 'account',
+      folderId: 'account:inbox',
+      subject: 'Shared subject',
+      sender: 'two@finestar.hr',
+      recipients: 'me@finestar.hr',
+      receivedAt: DateTime(2026, 4, 16, 10),
+      messageIdHeader: '<other@finestar.hr>',
+    );
+
+    final repository = MailboxRepositoryImpl(appDatabase: database);
+    final thread = await repository.getMessageThread(
+      accountId: 'account',
+      messageId: 'root',
+    );
+
+    expect(thread.messages.map((message) => message.id), ['root', 'reply']);
+  });
+
+  test('thread lookup is isolated by account id', () async {
+    final database = db.AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(database.close);
+
+    await _insertFolder(database, 'first:inbox', 'INBOX', accountId: 'first');
+    await _insertFolder(database, 'second:inbox', 'INBOX', accountId: 'second');
+    await _insertDetail(
+      database,
+      id: 'first-message',
+      accountId: 'first',
+      folderId: 'first:inbox',
+      subject: 'Same subject',
+      sender: 'one@finestar.hr',
+      recipients: 'me@finestar.hr',
+      receivedAt: DateTime(2026, 4, 16, 8),
+    );
+    await _insertDetail(
+      database,
+      id: 'second-message',
+      accountId: 'second',
+      folderId: 'second:inbox',
+      subject: 'Same subject',
+      sender: 'two@finestar.hr',
+      recipients: 'me@finestar.hr',
+      receivedAt: DateTime(2026, 4, 16, 9),
+    );
+
+    final repository = MailboxRepositoryImpl(appDatabase: database);
+    final thread = await repository.getMessageThread(
+      accountId: 'first',
+      messageId: 'first-message',
+    );
+
+    expect(thread.messages.map((message) => message.id), ['first-message']);
+  });
+}
+
+Future<void> _insertFolder(
+  db.AppDatabase database,
+  String id,
+  String name, {
+  String accountId = 'account',
+}) {
+  return database
+      .into(database.mailFolders)
+      .insert(
+        db.MailFoldersCompanion.insert(
+          id: id,
+          accountId: accountId,
+          name: name,
+          path: name,
+          isInbox: name == 'INBOX',
+        ),
+      );
+}
+
+Future<void> _insertDetail(
+  db.AppDatabase database, {
+  required String id,
+  required String accountId,
+  required String folderId,
+  required String subject,
+  required String sender,
+  required String recipients,
+  required DateTime receivedAt,
+  String bodyPlain = 'Body',
+  String? messageIdHeader,
+  String? inReplyToHeader,
+  String? referencesHeader,
+}) {
+  return database
+      .into(database.messageDetails)
+      .insert(
+        db.MessageDetailsCompanion.insert(
+          id: id,
+          accountId: Value(accountId),
+          folderId: Value(folderId),
+          subject: subject,
+          sender: sender,
+          recipients: recipients,
+          bodyPlain: bodyPlain,
+          bodyHtml: const Value(null),
+          receivedAt: receivedAt,
+          messageIdHeader: Value(messageIdHeader),
+          inReplyToHeader: Value(inReplyToHeader),
+          referencesHeader: Value(referencesHeader),
+        ),
+      );
 }

--- a/test/mailbox_screen_test.dart
+++ b/test/mailbox_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:finestar_mail/features/auth/presentation/auth_controller.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_folder.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_detail.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_summary.dart';
+import 'package:finestar_mail/features/mailbox/domain/entities/mail_thread.dart';
 import 'package:finestar_mail/features/mailbox/domain/repositories/mailbox_repository.dart';
 import 'package:finestar_mail/features/mailbox/presentation/mailbox_screen.dart';
 import 'package:flutter/material.dart';
@@ -181,6 +182,14 @@ class _FakeMailboxRepository implements MailboxRepository {
   Future<MailMessageDetail> getMessageDetail({
     required String accountId,
     required String id,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<MailThread> getMessageThread({
+    required String accountId,
+    required String messageId,
   }) {
     throw UnimplementedError();
   }

--- a/test/message_detail_screen_test.dart
+++ b/test/message_detail_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:finestar_mail/features/compose/domain/entities/reply_context.dar
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_folder.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_detail.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_summary.dart';
+import 'package:finestar_mail/features/mailbox/domain/entities/mail_thread.dart';
 import 'package:finestar_mail/features/mailbox/domain/repositories/mailbox_repository.dart';
 import 'package:finestar_mail/features/mailbox/presentation/message_detail_screen.dart';
 import 'package:flutter/material.dart';
@@ -16,58 +17,75 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
 void main() {
-  testWidgets('message detail renders main-screen content', (tester) async {
-    await tester.pumpWidget(_buildTestApp());
-    await tester.pumpAndSettle();
-
-    expect(find.text('Message'), findsOneWidget);
-    expect(find.text(_message.subject), findsOneWidget);
-    expect(
-      find.textContaining(_message.sender, findRichText: true),
-      findsOneWidget,
-    );
-    expect(
-      find.textContaining(_message.recipients.single, findRichText: true),
-      findsOneWidget,
-    );
-    expect(find.text('Apr 16, 2026 05:19'), findsOneWidget);
-    expect(find.text(_message.bodyPlain), findsOneWidget);
-    expect(find.text('Reply'), findsOneWidget);
-    expect(find.text('Reply all'), findsOneWidget);
-    expect(find.text('Forward'), findsOneWidget);
-
-    final actionRow = tester.widget<Row>(
-      find
-          .ancestor(of: find.text('Reply all'), matching: find.byType(Row))
-          .last,
-    );
-    expect(actionRow.children.whereType<Expanded>(), hasLength(3));
-  });
-
-  testWidgets('reply actions navigate with correct reply context', (
+  testWidgets('message detail renders chronological thread content', (
     tester,
   ) async {
     await tester.pumpWidget(_buildTestApp());
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Reply'));
-    await tester.pumpAndSettle();
-    expect(find.text('reply:${_message.sender}'), findsOneWidget);
+    expect(find.text(_thread.subject), findsOneWidget);
+    expect(find.textContaining('INBOX'), findsOneWidget);
+    expect(find.textContaining(_firstMessage.sender), findsOneWidget);
+    expect(find.textContaining(_secondMessage.sender), findsOneWidget);
+    expect(find.textContaining('Sent'), findsWidgets);
+    expect(find.text(_firstMessage.visibleBody), findsOneWidget);
+    expect(find.text(_secondMessage.visibleBody), findsOneWidget);
+    expect(find.text('Show quoted text'), findsOneWidget);
+  });
 
-    await tester.tap(find.byTooltip('Back'));
+  testWidgets('collapsed thread item expands when tapped', (tester) async {
+    await tester.pumpWidget(_buildTestApp());
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reply all'));
+
+    final bodyFinder = find.text(_firstMessage.visibleBody);
+    expect(tester.widget<Text>(bodyFinder).maxLines, 2);
+
+    await tester.tap(bodyFinder);
     await tester.pumpAndSettle();
+
+    expect(tester.widget<Text>(bodyFinder).maxLines, isNull);
+  });
+
+  testWidgets('quoted text can be shown and hidden', (tester) async {
+    await tester.pumpWidget(_buildTestApp());
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('original project kickoff'), findsNothing);
+
+    await tester.tap(find.text('Show quoted text'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hide quoted text'), findsOneWidget);
+    expect(find.textContaining('original project kickoff'), findsOneWidget);
+
+    await tester.tap(find.text('Hide quoted text'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Show quoted text'), findsOneWidget);
+    expect(find.textContaining('original project kickoff'), findsNothing);
+  });
+
+  testWidgets('per-message reply and forward use tapped message context', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildTestApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Reply').last);
+    await tester.pumpAndSettle();
+
     expect(
-      find.text('replyAll:${_message.sender},${_message.recipients.single}'),
+      find.text('reply:${_secondMessage.id}:${_secondMessage.sender}'),
       findsOneWidget,
     );
 
     await tester.tap(find.byTooltip('Back'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Forward'));
+
+    await tester.tap(find.byTooltip('Forward').first);
     await tester.pumpAndSettle();
-    expect(find.text('forward:'), findsOneWidget);
+
+    expect(find.text('forward:${_firstMessage.id}:'), findsOneWidget);
   });
 }
 
@@ -75,7 +93,7 @@ Widget _buildTestApp() {
   final router = GoRouter(
     initialLocation: AppRoute.messageDetail.path.replaceFirst(
       ':id',
-      _message.id,
+      _thread.selectedMessageId,
     ),
     routes: [
       GoRoute(
@@ -90,7 +108,7 @@ Widget _buildTestApp() {
           return Scaffold(
             appBar: AppBar(leading: BackButton(onPressed: () => context.pop())),
             body: Text(
-              '${replyContext.action.name}:${replyContext.recipients.join(',')}',
+              '${replyContext.action.name}:${replyContext.targetMessageId}:${replyContext.recipients.join(',')}',
             ),
           );
         },
@@ -127,14 +145,42 @@ final _account = MailAccount(
   createdAt: DateTime(2026, 4, 16),
 );
 
-final _message = MailMessageDetail(
+final _firstMessage = MailThreadMessage(
   id: 'message-1',
-  subject: 'Re: test',
+  folderId: 'avrcan@finestar.hr:inbox',
+  folderName: 'INBOX',
+  subject: 'probni mail',
   sender: 'ante@vitalgroupsa.com',
   recipients: const ['avrcan@finestar.hr'],
-  bodyPlain: 'ok\n\nOn 16/04/2026 05:17, Ante Vrcan wrote:\n> test proba',
+  bodyPlain:
+      'Ovo je prvi dio razgovora s dugim tekstom koji je defaultno skracen u thread kartici.',
   bodyHtml: null,
-  receivedAt: DateTime(2026, 4, 16, 5, 19),
+  receivedAt: DateTime(2026, 4, 16, 8, 2),
+  messageIdHeader: '<message-1@finestar.hr>',
+  inReplyToHeader: null,
+  referencesHeader: null,
+);
+
+final _secondMessage = MailThreadMessage(
+  id: 'message-2',
+  folderId: 'avrcan@finestar.hr:sent',
+  folderName: 'Sent',
+  subject: 'Re: probni mail',
+  sender: 'avrcan@finestar.hr',
+  recipients: const ['ante@vitalgroupsa.com'],
+  bodyPlain:
+      'Eto moj probni mail neka si mi napisao kako mislis da trebamo raditi.\n\nOn Thu, Apr 16, 2026 at 8:02 AM Ante wrote:\n> original project kickoff',
+  bodyHtml: null,
+  receivedAt: DateTime(2026, 4, 16, 8, 5),
+  messageIdHeader: '<message-2@finestar.hr>',
+  inReplyToHeader: '<message-1@finestar.hr>',
+  referencesHeader: '<message-1@finestar.hr>',
+);
+
+final _thread = MailThread(
+  subject: 'probni mail',
+  selectedMessageId: _secondMessage.id,
+  messages: [_firstMessage, _secondMessage],
 );
 
 class _FakeMailboxRepository implements MailboxRepository {
@@ -153,7 +199,15 @@ class _FakeMailboxRepository implements MailboxRepository {
   Future<MailMessageDetail> getMessageDetail({
     required String accountId,
     required String id,
-  }) async => _message;
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<MailThread> getMessageThread({
+    required String accountId,
+    required String messageId,
+  }) async => _thread;
 
   @override
   Future<List<MailMessageSummary>> getMessages({


### PR DESCRIPTION
## Summary
- Adds Gmail-style threaded message detail with chronological cards across cached folders.
- Adds targeted Sent-folder lookup when opening a thread so outgoing messages can appear in the conversation.
- Extends reply/forward compose context with quoted original text and RFC reply headers.

## Why
Message detail previously showed only the selected message, so conversations were hard to follow and Sent replies were missing unless already visible in the current mailbox view.

## Validation
- dart analyze
- flutter test

## Manual Testing Needed
- Test on a device/emulator with a real account and a conversation that has matching Inbox and Sent messages before merging.
