### PR TITLE
[codex] Render unified mail conversations

### DIFF
--- a/lib/data/remote/backend_mail_api_client.dart
+++ b/lib/data/remote/backend_mail_api_client.dart
@@ -70,6 +70,19 @@ class BackendMailApiClient {
     return BackendMessagesResponse.fromJson(json);
   }
 
+  Future<BackendUnifiedConversationsResponse> unifiedConversations({
+    required String token,
+    required int limit,
+  }) async {
+    final json = await _requestJson(
+      method: 'GET',
+      path: '/api/mail/unified-conversations',
+      queryParameters: {'limit': '$limit'},
+      token: token,
+    );
+    return BackendUnifiedConversationsResponse.fromJson(json);
+  }
+
   Future<BackendMessageDetailResponse> messageDetail({
     required String token,
     required String folder,
@@ -557,6 +570,105 @@ class BackendMessagesResponse {
   }
 }
 
+class BackendUnifiedConversationsResponse {
+  const BackendUnifiedConversationsResponse({
+    required this.accountEmail,
+    required this.folders,
+    required this.conversations,
+  });
+
+  final String accountEmail;
+  final List<BackendFolderDto> folders;
+  final List<BackendUnifiedConversationDto> conversations;
+
+  factory BackendUnifiedConversationsResponse.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return BackendUnifiedConversationsResponse(
+      accountEmail: json['account_email'] as String? ?? '',
+      folders: _listOfObjects(
+        json['folders'],
+      ).map(BackendFolderDto.fromJson).toList(),
+      conversations: _listOfObjects(
+        json['conversations'],
+      ).map(BackendUnifiedConversationDto.fromJson).toList(),
+    );
+  }
+}
+
+class BackendUnifiedConversationDto {
+  const BackendUnifiedConversationDto({
+    required this.conversationId,
+    required this.messageCount,
+    required this.replyCount,
+    required this.hasUnread,
+    required this.hasAttachments,
+    required this.hasVisibleAttachments,
+    required this.participants,
+    required this.messages,
+    required this.latestDate,
+  });
+
+  final String conversationId;
+  final int messageCount;
+  final int replyCount;
+  final bool hasUnread;
+  final bool hasAttachments;
+  final bool hasVisibleAttachments;
+  final List<BackendConversationParticipantDto> participants;
+  final List<BackendUnifiedConversationMessageDto> messages;
+  final DateTime? latestDate;
+
+  factory BackendUnifiedConversationDto.fromJson(Map<String, dynamic> json) {
+    return BackendUnifiedConversationDto(
+      conversationId: json['conversation_id'] as String? ?? '',
+      messageCount: json['message_count'] is num
+          ? (json['message_count'] as num).toInt()
+          : 0,
+      replyCount: json['reply_count'] is num
+          ? (json['reply_count'] as num).toInt()
+          : 0,
+      hasUnread: json['has_unread'] as bool? ?? false,
+      hasAttachments: json['has_attachments'] as bool? ?? false,
+      hasVisibleAttachments: json['has_visible_attachments'] as bool? ?? false,
+      participants: _conversationParticipants(json['participants']),
+      messages: _listOfObjects(
+        json['messages'],
+      ).map(BackendUnifiedConversationMessageDto.fromJson).toList(),
+      latestDate: _dateTime(json['latest_date']),
+    );
+  }
+}
+
+class BackendUnifiedConversationMessageDto {
+  const BackendUnifiedConversationMessageDto({
+    required this.summary,
+    required this.direction,
+  });
+
+  final BackendMessageSummaryDto summary;
+  final String direction;
+
+  factory BackendUnifiedConversationMessageDto.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return BackendUnifiedConversationMessageDto(
+      summary: BackendMessageSummaryDto.fromJson(json),
+      direction: json['direction'] as String? ?? 'inbound',
+    );
+  }
+}
+
+class BackendConversationParticipantDto {
+  const BackendConversationParticipantDto({
+    required this.name,
+    required this.email,
+  });
+
+  final String name;
+  final String email;
+}
+
 class BackendMessageDetailResponse {
   const BackendMessageDetailResponse({
     required this.accountEmail,
@@ -921,6 +1033,24 @@ List<String> _listOfStrings(Object? value) {
     return const [];
   }
   return value.map((item) => item.toString()).toList();
+}
+
+List<BackendConversationParticipantDto> _conversationParticipants(
+  Object? value,
+) {
+  if (value is! List) {
+    return const [];
+  }
+  return value.map((item) {
+    if (item is Map<String, dynamic>) {
+      return BackendConversationParticipantDto(
+        name: item['name'] as String? ?? '',
+        email: item['email'] as String? ?? '',
+      );
+    }
+    final email = item.toString();
+    return BackendConversationParticipantDto(name: '', email: email);
+  }).toList();
 }
 
 DateTime? _dateTime(Object? value) {

--- a/lib/features/mailbox/data/mailbox_repository_impl.dart
+++ b/lib/features/mailbox/data/mailbox_repository_impl.dart
@@ -5,6 +5,7 @@ import 'package:drift/drift.dart';
 import '../../../data/local/app_database.dart' as db;
 import '../../../data/remote/backend_mail_api_client.dart';
 import '../../../data/secure/secure_storage_service.dart';
+import '../domain/entities/mail_conversation.dart';
 import '../domain/entities/mail_delete_result.dart';
 import '../domain/entities/mail_folder.dart' as domain;
 import '../domain/entities/mail_message_attachment.dart';
@@ -108,21 +109,25 @@ class MailboxRepositoryImpl implements MailboxRepository {
     final response = await _backendMailApiClient!.folders(token: token);
     return response.folders
         .where((folder) => _backendFolderPath(folder).isNotEmpty)
-        .map((folder) {
-          final path = _backendFolderPath(folder);
-          return domain.MailFolder(
-            id: _folderId(accountId, path),
-            name: folder.name.trim().isEmpty ? path : folder.name,
-            path: path,
-            isInbox: _isInboxPath(path),
-            displayName: _backendFolderDisplayName(folder, path),
-            parentPath: _backendFolderParentPath(folder, path),
-            depth: _backendFolderDepth(folder, path),
-            selectable:
-                folder.selectable && !_hasFlag(folder.flags, 'Noselect'),
-          );
-        })
+        .map((folder) => _mailFolderFromBackend(accountId, folder))
         .toList();
+  }
+
+  domain.MailFolder _mailFolderFromBackend(
+    String accountId,
+    BackendFolderDto folder,
+  ) {
+    final path = _backendFolderPath(folder);
+    return domain.MailFolder(
+      id: _folderId(accountId, path),
+      name: folder.name.trim().isEmpty ? path : folder.name,
+      path: path,
+      isInbox: _isInboxPath(path),
+      displayName: _backendFolderDisplayName(folder, path),
+      parentPath: _backendFolderParentPath(folder, path),
+      depth: _backendFolderDepth(folder, path),
+      selectable: folder.selectable && !_hasFlag(folder.flags, 'Noselect'),
+    );
   }
 
   Future<void> _replaceCachedFolders(
@@ -364,6 +369,148 @@ class MailboxRepositoryImpl implements MailboxRepository {
     );
   }
 
+  @override
+  Future<List<MailConversation>> getUnifiedConversations({
+    required String accountId,
+    int limit = 50,
+    bool forceRefresh = false,
+  }) async {
+    final remoteConversations = await _fetchBackendUnifiedConversations(
+      accountId: accountId,
+      limit: limit,
+    );
+    if (remoteConversations != null) {
+      return remoteConversations;
+    }
+
+    final inbox = domain.MailFolder(
+      id: _folderId(accountId, 'INBOX'),
+      name: 'INBOX',
+      path: 'INBOX',
+      isInbox: true,
+    );
+    final page = await getMessagePage(
+      accountId: accountId,
+      folder: inbox,
+      pageSize: limit,
+      forceRefresh: forceRefresh,
+    );
+    return page.messages.map((message) {
+      return MailConversation(
+        id: message.id,
+        messageCount: 1,
+        replyCount: 0,
+        hasUnread: !message.isRead,
+        hasAttachments: message.hasAttachments,
+        hasVisibleAttachments: message.hasAttachments,
+        participants: [
+          MailConversationParticipant(name: '', email: message.sender),
+        ],
+        messages: [
+          MailConversationMessage(
+            message: message,
+            direction: MailConversationDirection.inbound,
+          ),
+        ],
+        latestDate: message.receivedAt,
+      );
+    }).toList();
+  }
+
+  Future<List<MailConversation>?> _fetchBackendUnifiedConversations({
+    required String accountId,
+    required int limit,
+  }) async {
+    final token = await _authToken(accountId);
+    if (token == null) {
+      return null;
+    }
+
+    late final BackendUnifiedConversationsResponse response;
+    try {
+      response = await _backendMailApiClient!.unifiedConversations(
+        token: token,
+        limit: limit,
+      );
+    } on BackendMailApiException catch (error) {
+      if (error.statusCode == 404) {
+        return null;
+      }
+      rethrow;
+    }
+
+    if (response.folders.isNotEmpty) {
+      final folders = response.folders
+          .where((folder) => _backendFolderPath(folder).isNotEmpty)
+          .map((folder) => _mailFolderFromBackend(accountId, folder))
+          .toList();
+      if (folders.isNotEmpty) {
+        await _replaceCachedFolders(accountId, folders);
+      }
+    }
+
+    final inbox = domain.MailFolder(
+      id: _folderId(accountId, 'INBOX'),
+      name: 'INBOX',
+      path: 'INBOX',
+      isInbox: true,
+    );
+    final allMessages = <BackendMessageSummaryDto>[
+      for (final conversation in response.conversations)
+        for (final message in conversation.messages) message.summary,
+    ];
+    final cachedSummaries = await _cacheBackendSummaries(
+      accountId,
+      inbox,
+      allMessages,
+    );
+    final summariesById = {
+      for (final summary in cachedSummaries) summary.id: summary,
+    };
+
+    return response.conversations.map((conversation) {
+      final messages = conversation.messages.map((message) {
+        final summary = message.summary;
+        final folderPath = summary.folder.isEmpty ? inbox.path : summary.folder;
+        final id = _messageId(accountId, folderPath, summary.uid);
+        return MailConversationMessage(
+          message:
+              summariesById[id] ??
+              _summaryFromBackendMessage(accountId, inbox, summary),
+          direction: _conversationDirection(message.direction),
+        );
+      }).toList();
+      final firstMessage = messages.isEmpty ? null : messages.first.message;
+      return MailConversation(
+        id: conversation.conversationId.isEmpty
+            ? firstMessage?.id ?? ''
+            : conversation.conversationId,
+        messageCount: conversation.messageCount == 0
+            ? messages.length
+            : conversation.messageCount,
+        replyCount: conversation.replyCount == 0 && messages.isNotEmpty
+            ? messages.length - 1
+            : conversation.replyCount,
+        hasUnread: conversation.hasUnread,
+        hasAttachments: conversation.hasAttachments,
+        hasVisibleAttachments: conversation.hasVisibleAttachments,
+        participants: conversation.participants
+            .map(
+              (participant) => MailConversationParticipant(
+                name: participant.name,
+                email: participant.email,
+              ),
+            )
+            .toList(),
+        messages: messages,
+        latestDate:
+            conversation.latestDate ??
+            firstMessage?.receivedAt ??
+            DateTime.now(),
+      );
+    }).toList();
+  }
+
   Future<MailMessagePage> _cachedMessagePage({
     required String accountId,
     required domain.MailFolder folder,
@@ -478,6 +625,37 @@ class MailboxRepositoryImpl implements MailboxRepository {
     });
 
     return _sortSummaries(mergedSummaries);
+  }
+
+  MailMessageSummary _summaryFromBackendMessage(
+    String accountId,
+    domain.MailFolder folder,
+    BackendMessageSummaryDto message,
+  ) {
+    final folderPath = message.folder.isEmpty ? folder.path : message.folder;
+    final folderId = _folderId(accountId, folderPath);
+    return MailMessageSummary(
+      id: _messageId(accountId, folderPath, message.uid),
+      folderId: folderId,
+      subject: _subject(message.subject),
+      sender: _sender(message.sender),
+      preview: _preview(message.subject),
+      receivedAt: message.date ?? DateTime.now(),
+      isRead: _hasFlag(message.flags, 'seen'),
+      isImportant: _hasFlag(message.flags, 'flagged'),
+      hasAttachments: message.hasVisibleAttachments ?? message.hasAttachments,
+      sequence: int.tryParse(message.uid) ?? 0,
+    );
+  }
+
+  MailConversationDirection _conversationDirection(String direction) {
+    switch (direction.trim().toLowerCase()) {
+      case 'outbound':
+        return MailConversationDirection.outbound;
+      case 'inbound':
+      default:
+        return MailConversationDirection.inbound;
+    }
   }
 
   @override

--- a/lib/features/mailbox/domain/entities/mail_conversation.dart
+++ b/lib/features/mailbox/domain/entities/mail_conversation.dart
@@ -1,0 +1,44 @@
+import 'mail_message_summary.dart';
+
+enum MailConversationDirection { inbound, outbound }
+
+class MailConversationParticipant {
+  const MailConversationParticipant({required this.name, required this.email});
+
+  final String name;
+  final String email;
+}
+
+class MailConversationMessage {
+  const MailConversationMessage({
+    required this.message,
+    required this.direction,
+  });
+
+  final MailMessageSummary message;
+  final MailConversationDirection direction;
+}
+
+class MailConversation {
+  const MailConversation({
+    required this.id,
+    required this.messageCount,
+    required this.replyCount,
+    required this.hasUnread,
+    required this.hasAttachments,
+    required this.hasVisibleAttachments,
+    required this.participants,
+    required this.messages,
+    required this.latestDate,
+  });
+
+  final String id;
+  final int messageCount;
+  final int replyCount;
+  final bool hasUnread;
+  final bool hasAttachments;
+  final bool hasVisibleAttachments;
+  final List<MailConversationParticipant> participants;
+  final List<MailConversationMessage> messages;
+  final DateTime latestDate;
+}

--- a/lib/features/mailbox/domain/repositories/mailbox_repository.dart
+++ b/lib/features/mailbox/domain/repositories/mailbox_repository.dart
@@ -1,4 +1,5 @@
 import '../entities/mail_folder.dart';
+import '../entities/mail_conversation.dart';
 import '../entities/mail_delete_result.dart';
 import '../entities/mail_message_detail.dart';
 import '../entities/mail_message_attachment.dart';
@@ -23,6 +24,12 @@ abstract class MailboxRepository {
     required MailFolder folder,
     int pageSize = 50,
     String? beforeUid,
+    bool forceRefresh = false,
+  });
+
+  Future<List<MailConversation>> getUnifiedConversations({
+    required String accountId,
+    int limit = 50,
     bool forceRefresh = false,
   });
 

--- a/lib/features/mailbox/presentation/mailbox_controller.dart
+++ b/lib/features/mailbox/presentation/mailbox_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../app/providers.dart';
 import '../../auth/presentation/auth_controller.dart';
 import '../domain/entities/mail_delete_result.dart';
+import '../domain/entities/mail_conversation.dart';
 import '../domain/entities/mail_folder.dart';
 import '../domain/entities/mail_message_detail.dart';
 import '../domain/entities/mail_message_page.dart';
@@ -56,6 +57,204 @@ final folderMessagesProvider = FutureProvider.autoDispose
       );
       return page.messages;
     });
+
+final mailboxConversationsControllerProvider = AsyncNotifierProvider.autoDispose
+    .family<
+      MailboxConversationsController,
+      MailboxConversationsState,
+      MailFolder
+    >(MailboxConversationsController.new);
+
+class MailboxConversationsState {
+  const MailboxConversationsState({required this.conversations});
+
+  final List<MailConversation> conversations;
+
+  MailboxConversationsState copyWith({List<MailConversation>? conversations}) {
+    return MailboxConversationsState(
+      conversations: conversations ?? this.conversations,
+    );
+  }
+}
+
+class MailboxConversationsController
+    extends AsyncNotifier<MailboxConversationsState> {
+  MailboxConversationsController(this.folder);
+
+  static const limit = 50;
+
+  final MailFolder folder;
+
+  @override
+  Future<MailboxConversationsState> build() async {
+    return _loadConversations(forceRefresh: true);
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () => _loadConversations(forceRefresh: true),
+    );
+  }
+
+  Future<MailDeleteResult> moveSelectedToTrash(List<String> messageIds) async {
+    final current = state.asData?.value;
+    if (current == null || messageIds.isEmpty) {
+      return const MailDeleteResult(movedMessageIds: [], failed: []);
+    }
+
+    final account = await ref.read(activeAccountProvider.future);
+    if (account == null) {
+      return MailDeleteResult(
+        movedMessageIds: const [],
+        failed: messageIds
+            .map(
+              (id) => MailDeleteFailure(
+                messageId: id,
+                message: 'Active account session is missing.',
+              ),
+            )
+            .toList(),
+      );
+    }
+
+    final repository = ref.read(mailboxRepositoryProvider);
+    final results = <MailDeleteResult>[];
+    for (final messageId in messageIds) {
+      results.add(
+        await repository.moveMessageToTrash(
+          accountId: account.id,
+          messageId: messageId,
+        ),
+      );
+    }
+    final result = MailDeleteResult(
+      movedMessageIds: [
+        for (final result in results) ...result.movedMessageIds,
+      ],
+      failed: [for (final result in results) ...result.failed],
+    );
+    if (result.movedMessageIds.isNotEmpty) {
+      state = AsyncData(
+        current.copyWith(
+          conversations: _removeMessagesFromConversations(
+            current.conversations,
+            result.movedMessageIds.toSet(),
+          ),
+        ),
+      );
+    }
+    return result;
+  }
+
+  Future<MailRestoreResult> restoreSelectedToInbox(
+    List<String> messageIds,
+  ) async {
+    final current = state.asData?.value;
+    if (current == null || messageIds.isEmpty) {
+      return const MailRestoreResult(restoredMessageIds: [], failed: []);
+    }
+
+    final account = await ref.read(activeAccountProvider.future);
+    if (account == null) {
+      return MailRestoreResult(
+        restoredMessageIds: const [],
+        failed: messageIds
+            .map(
+              (id) => MailRestoreFailure(
+                messageId: id,
+                message: 'Active account session is missing.',
+              ),
+            )
+            .toList(),
+      );
+    }
+
+    final repository = ref.read(mailboxRepositoryProvider);
+    final results = <MailRestoreResult>[];
+    for (final messageId in messageIds) {
+      results.add(
+        await repository.restoreMessageToInbox(
+          accountId: account.id,
+          messageId: messageId,
+        ),
+      );
+    }
+    final result = MailRestoreResult(
+      restoredMessageIds: [
+        for (final result in results) ...result.restoredMessageIds,
+      ],
+      failed: [for (final result in results) ...result.failed],
+    );
+    if (result.restoredMessageIds.isNotEmpty) {
+      state = AsyncData(
+        current.copyWith(
+          conversations: _removeMessagesFromConversations(
+            current.conversations,
+            result.restoredMessageIds.toSet(),
+          ),
+        ),
+      );
+    }
+    return result;
+  }
+
+  Future<MailboxConversationsState> _loadConversations({
+    required bool forceRefresh,
+  }) async {
+    final account = await ref.watch(activeAccountProvider.future);
+    if (account == null) {
+      return const MailboxConversationsState(conversations: []);
+    }
+
+    final conversations = await ref
+        .watch(mailboxRepositoryProvider)
+        .getUnifiedConversations(
+          accountId: account.id,
+          limit: limit,
+          forceRefresh: forceRefresh,
+        );
+    return MailboxConversationsState(conversations: conversations);
+  }
+
+  List<MailConversation> _removeMessagesFromConversations(
+    List<MailConversation> conversations,
+    Set<String> messageIds,
+  ) {
+    return conversations
+        .map((conversation) {
+          final remaining = conversation.messages
+              .where((message) => !messageIds.contains(message.message.id))
+              .toList();
+          if (remaining.isEmpty) {
+            return null;
+          }
+          return MailConversation(
+            id: conversation.id,
+            messageCount: remaining.length,
+            replyCount: remaining.length - 1,
+            hasUnread: remaining.any((message) => !message.message.isRead),
+            hasAttachments: remaining.any(
+              (message) => message.message.hasAttachments,
+            ),
+            hasVisibleAttachments: remaining.any(
+              (message) => message.message.hasAttachments,
+            ),
+            participants: conversation.participants,
+            messages: remaining,
+            latestDate: remaining
+                .map((message) => message.message.receivedAt)
+                .reduce(_latestDate),
+          );
+        })
+        .whereType<MailConversation>()
+        .toList();
+  }
+
+  DateTime _latestDate(DateTime left, DateTime right) {
+    return right.isAfter(left) ? right : left;
+  }
+}
 
 class MailboxMessagesState {
   const MailboxMessagesState({

--- a/lib/features/mailbox/presentation/mailbox_screen.dart
+++ b/lib/features/mailbox/presentation/mailbox_screen.dart
@@ -11,6 +11,7 @@ import '../../../app/providers.dart';
 import '../../../app/router/app_route.dart';
 import '../../auth/domain/entities/mail_account.dart';
 import '../../auth/presentation/auth_controller.dart';
+import '../domain/entities/mail_conversation.dart';
 import '../domain/entities/mail_folder.dart';
 import '../domain/entities/mail_message_summary.dart';
 import 'mailbox_controller.dart';
@@ -83,9 +84,13 @@ class _MailboxScreenState extends ConsumerState<MailboxScreen> {
     setState(() => _isProcessingSelection = true);
     final requestedIds = _selectedMessageIds.toList();
     try {
-      final result = await ref
-          .read(mailboxMessagesControllerProvider(folder).notifier)
-          .moveSelectedToTrash(requestedIds);
+      final result = _isInbox(folder)
+          ? await ref
+                .read(mailboxConversationsControllerProvider(folder).notifier)
+                .moveSelectedToTrash(requestedIds)
+          : await ref
+                .read(mailboxMessagesControllerProvider(folder).notifier)
+                .moveSelectedToTrash(requestedIds);
       if (!mounted) {
         return;
       }
@@ -139,9 +144,13 @@ class _MailboxScreenState extends ConsumerState<MailboxScreen> {
     setState(() => _isProcessingSelection = true);
     final requestedIds = _selectedMessageIds.toList();
     try {
-      final result = await ref
-          .read(mailboxMessagesControllerProvider(folder).notifier)
-          .restoreSelectedToInbox(requestedIds);
+      final result = _isInbox(folder)
+          ? await ref
+                .read(mailboxConversationsControllerProvider(folder).notifier)
+                .restoreSelectedToInbox(requestedIds)
+          : await ref
+                .read(mailboxMessagesControllerProvider(folder).notifier)
+                .restoreSelectedToInbox(requestedIds);
       if (!mounted) {
         return;
       }
@@ -828,7 +837,9 @@ class _MailboxContentState extends ConsumerState<_MailboxContent> {
   }
 
   void _maybeLoadMore() {
-    if (widget.searchQuery.isNotEmpty || !_scrollController.hasClients) {
+    if (widget.searchQuery.isNotEmpty ||
+        _isInbox(widget.folder) ||
+        !_scrollController.hasClients) {
       return;
     }
     final position = _scrollController.position;
@@ -852,13 +863,21 @@ class _MailboxContentState extends ConsumerState<_MailboxContent> {
     final searchAsync = isSearching
         ? ref.watch(mailboxSearchProvider(searchRequest))
         : null;
-    final pagedAsync = isSearching
+    final showConversations = !isSearching && _isInbox(folder);
+    final conversationsAsync = showConversations
+        ? ref.watch(mailboxConversationsControllerProvider(folder))
+        : null;
+    final pagedAsync = isSearching || showConversations
         ? null
         : ref.watch(mailboxMessagesControllerProvider(folder));
 
     return RefreshIndicator(
       onRefresh: () => isSearching
           ? ref.refresh(mailboxSearchProvider(searchRequest).future)
+          : showConversations
+          ? ref
+                .read(mailboxConversationsControllerProvider(folder).notifier)
+                .refresh()
           : ref
                 .read(mailboxMessagesControllerProvider(folder).notifier)
                 .refresh(),
@@ -874,51 +893,349 @@ class _MailboxContentState extends ConsumerState<_MailboxContent> {
                 style: Theme.of(context).textTheme.titleMedium,
               ),
             ),
-          (isSearching ? searchAsync! : pagedAsync!).when(
-            data: (messages) {
-              final visibleMessages = isSearching
-                  ? messages as List<MailMessageSummary>
-                  : (messages as MailboxMessagesState).messages;
-              if (visibleMessages.isEmpty) {
-                return EmptyStateView(
-                  title: isSearching ? 'No matching mail' : 'No messages yet',
-                  message: isSearching
-                      ? 'Try another keyword or clear the search.'
-                      : 'Once ${_folderLabel(folder)} syncs, messages will appear here.',
-                );
-              }
+          (isSearching
+                  ? searchAsync!
+                  : showConversations
+                  ? conversationsAsync!
+                  : pagedAsync!)
+              .when(
+                data: (data) {
+                  if (showConversations) {
+                    final conversations =
+                        (data as MailboxConversationsState).conversations;
+                    if (conversations.isEmpty) {
+                      return EmptyStateView(
+                        title: 'No messages yet',
+                        message:
+                            'Once ${_folderLabel(folder)} syncs, messages will appear here.',
+                      );
+                    }
+                    return _ConversationList(
+                      conversations: conversations,
+                      folder: folder,
+                      selectedMessageIds: widget.selectedMessageIds,
+                      onToggleSelected: widget.onToggleSelected,
+                    );
+                  }
 
-              return Column(
+                  final visibleMessages = isSearching
+                      ? data as List<MailMessageSummary>
+                      : (data as MailboxMessagesState).messages;
+                  if (visibleMessages.isEmpty) {
+                    return EmptyStateView(
+                      title: isSearching
+                          ? 'No matching mail'
+                          : 'No messages yet',
+                      message: isSearching
+                          ? 'Try another keyword or clear the search.'
+                          : 'Once ${_folderLabel(folder)} syncs, messages will appear here.',
+                    );
+                  }
+
+                  return Column(
+                    children: [
+                      _MessageList(
+                        messages: visibleMessages,
+                        folder: folder,
+                        selectedMessageIds: widget.selectedMessageIds,
+                        selectionEnabled: !isSearching,
+                        onToggleSelected: widget.onToggleSelected,
+                      ),
+                      if (!isSearching)
+                        _LoadMoreFooter(
+                          state: data as MailboxMessagesState,
+                          onRetry: () => ref
+                              .read(
+                                mailboxMessagesControllerProvider(
+                                  folder,
+                                ).notifier,
+                              )
+                              .loadMore(),
+                        ),
+                    ],
+                  );
+                },
+                error: (error, stackTrace) => ErrorStateView(
+                  message: error.toString(),
+                  onRetry: () => isSearching
+                      ? ref.invalidate(mailboxSearchProvider(searchRequest))
+                      : showConversations
+                      ? ref.invalidate(
+                          mailboxConversationsControllerProvider(folder),
+                        )
+                      : ref.invalidate(
+                          mailboxMessagesControllerProvider(folder),
+                        ),
+                ),
+                loading: () => const Center(child: CircularProgressIndicator()),
+              ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConversationList extends ConsumerWidget {
+  const _ConversationList({
+    required this.conversations,
+    required this.folder,
+    required this.selectedMessageIds,
+    required this.onToggleSelected,
+  });
+
+  final List<MailConversation> conversations;
+  final MailFolder folder;
+  final Set<String> selectedMessageIds;
+  final ValueChanged<String> onToggleSelected;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      children: [
+        for (final conversation in conversations)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 10),
+            child: SectionCard(
+              color:
+                  conversation.messages.any(
+                    (message) =>
+                        selectedMessageIds.contains(message.message.id),
+                  )
+                  ? const Color(0xFFD7EAFE)
+                  : conversation.hasUnread
+                  ? const Color(0xFFEAF4FF)
+                  : Colors.white,
+              padding: const EdgeInsets.all(0),
+              child: Column(
                 children: [
-                  _MessageList(
-                    messages: visibleMessages,
-                    folder: folder,
-                    selectedMessageIds: widget.selectedMessageIds,
-                    selectionEnabled: !isSearching,
-                    onToggleSelected: widget.onToggleSelected,
-                  ),
-                  if (!isSearching)
-                    _LoadMoreFooter(
-                      state: messages as MailboxMessagesState,
-                      onRetry: () => ref
-                          .read(
-                            mailboxMessagesControllerProvider(folder).notifier,
-                          )
-                          .loadMore(),
+                  for (
+                    var index = 0;
+                    index < conversation.messages.length;
+                    index++
+                  )
+                    _ConversationMessageRow(
+                      item: conversation.messages[index],
+                      folder: folder,
+                      selected: selectedMessageIds.contains(
+                        conversation.messages[index].message.id,
+                      ),
+                      selectionActive: selectedMessageIds.isNotEmpty,
+                      onToggleSelected: onToggleSelected,
+                      aggregateHasAttachments: index == 0
+                          ? conversation.hasVisibleAttachments
+                          : null,
+                      aggregateUnread: index == 0
+                          ? conversation.hasUnread
+                          : null,
+                      replyCount: index == 0 ? conversation.replyCount : 0,
+                      isThreadChild: index > 0,
+                      isLast: index == conversation.messages.length - 1,
                     ),
                 ],
-              );
-            },
-            error: (error, stackTrace) => ErrorStateView(
-              message: error.toString(),
-              onRetry: () => isSearching
-                  ? ref.invalidate(mailboxSearchProvider(searchRequest))
-                  : ref.invalidate(mailboxMessagesControllerProvider(folder)),
+              ),
             ),
-            loading: () => const Center(child: CircularProgressIndicator()),
+          ),
+      ],
+    );
+  }
+}
+
+class _ConversationMessageRow extends ConsumerWidget {
+  const _ConversationMessageRow({
+    required this.item,
+    required this.folder,
+    required this.selected,
+    required this.selectionActive,
+    required this.onToggleSelected,
+    required this.isThreadChild,
+    required this.isLast,
+    this.aggregateHasAttachments,
+    this.aggregateUnread,
+    this.replyCount = 0,
+  });
+
+  final MailConversationMessage item;
+  final MailFolder folder;
+  final bool selected;
+  final bool selectionActive;
+  final ValueChanged<String> onToggleSelected;
+  final bool isThreadChild;
+  final bool isLast;
+  final bool? aggregateHasAttachments;
+  final bool? aggregateUnread;
+  final int replyCount;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final child = _ConversationListTile(
+      item: item,
+      folder: folder,
+      selected: selected,
+      selectionActive: selectionActive,
+      onToggleSelected: onToggleSelected,
+      aggregateHasAttachments: aggregateHasAttachments,
+      aggregateUnread: aggregateUnread,
+      replyCount: replyCount,
+    );
+    if (!isThreadChild) {
+      return child;
+    }
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 42,
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: Container(
+              width: 2,
+              height: isLast ? 58 : 92,
+              color: const Color(0xFFDADCE0),
+            ),
+          ),
+        ),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+
+class _ConversationListTile extends ConsumerWidget {
+  const _ConversationListTile({
+    required this.item,
+    required this.folder,
+    required this.selected,
+    required this.selectionActive,
+    required this.onToggleSelected,
+    this.aggregateHasAttachments,
+    this.aggregateUnread,
+    this.replyCount = 0,
+  });
+
+  final MailConversationMessage item;
+  final MailFolder folder;
+  final bool selected;
+  final bool selectionActive;
+  final ValueChanged<String> onToggleSelected;
+  final bool? aggregateHasAttachments;
+  final bool? aggregateUnread;
+  final int replyCount;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final message = item.message;
+    final formatter = DateFormat('MMM d');
+    final isOutbound = item.direction == MailConversationDirection.outbound;
+    final isUnread = aggregateUnread ?? !message.isRead;
+    final hasAttachments = aggregateHasAttachments ?? message.hasAttachments;
+    return ListTile(
+      onLongPress: () => _showConversationActions(
+        context: context,
+        ref: ref,
+        message: message,
+        folder: folder,
+      ),
+      onTap: selectionActive
+          ? () => onToggleSelected(message.id)
+          : () => context.push(
+              AppRoute.messageDetail.path.replaceFirst(':id', message.id),
+            ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      leading: Tooltip(
+        message: 'Select message',
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: () => onToggleSelected(message.id),
+          child: CircleAvatar(
+            backgroundColor: selected
+                ? Theme.of(context).colorScheme.primary
+                : const Color(0xFFE8EFF8),
+            child: selected
+                ? const Icon(Icons.check, color: Colors.white, size: 20)
+                : Text(
+                    _senderInitial(message.sender),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+          ),
+        ),
+      ),
+      title: Row(
+        children: [
+          if (isOutbound) ...[
+            const Icon(Icons.send_outlined, size: 15),
+            const SizedBox(width: 5),
+            Text(
+              'Sent',
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                color: const Color(0xFF2563A8),
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(width: 8),
+          ],
+          Expanded(
+            child: Text(
+              message.subject,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontWeight: isUnread ? FontWeight.w800 : FontWeight.w500,
+              ),
+            ),
+          ),
+          if (replyCount > 0) ...[
+            const SizedBox(width: 8),
+            Text(
+              '$replyCount replies',
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                color: const Color(0xFF5F6368),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ],
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Text(
+          '${message.sender}\n${message.preview}',
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+      trailing: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(formatter.format(message.receivedAt)),
+          const SizedBox(height: 6),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (message.isImportant)
+                const Icon(Icons.error, size: 16, color: Color(0xFFD93025)),
+              if (message.isPinned)
+                const Padding(
+                  padding: EdgeInsets.only(left: 4),
+                  child: Icon(
+                    Icons.push_pin,
+                    size: 16,
+                    color: Color(0xFF153B52),
+                  ),
+                ),
+              if (hasAttachments)
+                const Padding(
+                  padding: EdgeInsets.only(left: 4),
+                  child: Icon(Icons.attach_file, size: 16),
+                ),
+            ],
           ),
         ],
       ),
+      isThreeLine: true,
     );
   }
 }
@@ -1176,6 +1493,92 @@ class _MessageList extends ConsumerWidget {
       },
     );
   }
+}
+
+String _senderInitial(String sender) {
+  final trimmed = sender.trim();
+  if (trimmed.isEmpty) {
+    return '?';
+  }
+  return trimmed.characters.first.toUpperCase();
+}
+
+Future<void> _showConversationActions({
+  required BuildContext context,
+  required WidgetRef ref,
+  required MailMessageSummary message,
+  required MailFolder folder,
+}) async {
+  final account = ref.read(activeAccountProvider).asData?.value;
+  if (account == null) {
+    return;
+  }
+
+  Future<void> apply(Future<void> Function() action) async {
+    Navigator.of(context).pop();
+    await action();
+    ref.invalidate(mailboxConversationsControllerProvider(folder));
+    ref.invalidate(mailboxMessagesControllerProvider(folder));
+  }
+
+  await showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    builder: (sheetContext) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: Icon(
+                message.isRead
+                    ? Icons.mark_email_unread_outlined
+                    : Icons.mark_email_read_outlined,
+              ),
+              title: Text(message.isRead ? 'Mark as unread' : 'Mark as read'),
+              onTap: () => apply(
+                () => ref
+                    .read(mailboxRepositoryProvider)
+                    .setMessageRead(
+                      accountId: account.id,
+                      messageId: message.id,
+                      isRead: !message.isRead,
+                    ),
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.error_outline),
+              title: Text(
+                message.isImportant ? 'Remove important' : 'Mark important',
+              ),
+              onTap: () => apply(
+                () => ref
+                    .read(mailboxRepositoryProvider)
+                    .setMessageImportant(
+                      accountId: account.id,
+                      messageId: message.id,
+                      isImportant: !message.isImportant,
+                    ),
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.push_pin_outlined),
+              title: Text(message.isPinned ? 'Unpin' : 'Pin to top'),
+              onTap: () => apply(
+                () => ref
+                    .read(mailboxRepositoryProvider)
+                    .setMessagePinned(
+                      accountId: account.id,
+                      messageId: message.id,
+                      isPinned: !message.isPinned,
+                    ),
+              ),
+            ),
+          ],
+        ),
+      );
+    },
+  );
 }
 
 enum _FolderRole { inbox, sent, drafts, trash, junk, archive, custom }

--- a/test/backend_mail_api_client_test.dart
+++ b/test/backend_mail_api_client_test.dart
@@ -216,6 +216,91 @@ void main() {
     },
   );
 
+  test('unifiedConversations parses timeline response', () async {
+    http.Request? capturedRequest;
+    final client = BackendMailApiClient(
+      httpClient: MockClient((request) async {
+        capturedRequest = request;
+        return http.Response(
+          jsonEncode({
+            'account_email': 'app-test-1@finestar.hr',
+            'folders': [
+              {'name': 'INBOX', 'path': 'INBOX'},
+              {'name': 'Sent', 'path': 'Sent'},
+            ],
+            'conversations': [
+              {
+                'conversation_id': 'unified-1',
+                'message_count': 2,
+                'reply_count': 1,
+                'has_unread': true,
+                'has_attachments': true,
+                'has_visible_attachments': false,
+                'participants': [
+                  {'name': 'Client', 'email': 'client@example.test'},
+                ],
+                'latest_date': '2026-04-17T10:00:00Z',
+                'messages': [
+                  {
+                    'uid': '40',
+                    'folder': 'INBOX',
+                    'direction': 'inbound',
+                    'subject': 'Unified root',
+                    'sender': 'client@example.test',
+                    'to': ['app-test-1@finestar.hr'],
+                    'cc': [],
+                    'date': '2026-04-17T08:00:00Z',
+                    'message_id': '<root@example.test>',
+                    'flags': [],
+                    'size': 123,
+                    'has_attachments': false,
+                    'has_visible_attachments': false,
+                  },
+                  {
+                    'uid': '12',
+                    'folder': 'Sent',
+                    'direction': 'outbound',
+                    'subject': 'Re: Unified root',
+                    'sender': 'app-test-1@finestar.hr',
+                    'to': ['client@example.test'],
+                    'cc': [],
+                    'date': '2026-04-17T10:00:00Z',
+                    'message_id': '<reply@example.test>',
+                    'flags': ['Seen'],
+                    'size': 456,
+                    'has_attachments': true,
+                    'has_visible_attachments': false,
+                  },
+                ],
+              },
+            ],
+          }),
+          200,
+        );
+      }),
+      baseUrlLoader: () async => 'https://mail.example.test',
+    );
+
+    final response = await client.unifiedConversations(
+      token: 'session-token',
+      limit: 50,
+    );
+
+    expect(capturedRequest?.url.path, '/api/mail/unified-conversations');
+    expect(capturedRequest?.url.queryParameters, {'limit': '50'});
+    expect(response.accountEmail, 'app-test-1@finestar.hr');
+    expect(response.folders.map((folder) => folder.path), ['INBOX', 'Sent']);
+    final conversation = response.conversations.single;
+    expect(conversation.conversationId, 'unified-1');
+    expect(conversation.hasUnread, isTrue);
+    expect(conversation.hasAttachments, isTrue);
+    expect(conversation.hasVisibleAttachments, isFalse);
+    expect(conversation.messages.first.summary.folder, 'INBOX');
+    expect(conversation.messages.first.direction, 'inbound');
+    expect(conversation.messages.last.summary.folder, 'Sent');
+    expect(conversation.messages.last.direction, 'outbound');
+  });
+
   test('folders parses hierarchy metadata when present', () async {
     final client = BackendMailApiClient(
       httpClient: MockClient((request) async {

--- a/test/backend_repository_migration_test.dart
+++ b/test/backend_repository_migration_test.dart
@@ -13,6 +13,7 @@ import 'package:finestar_mail/features/auth/domain/entities/connection_settings.
 import 'package:finestar_mail/features/compose/data/compose_repository_impl.dart';
 import 'package:finestar_mail/features/compose/domain/entities/outgoing_message.dart';
 import 'package:finestar_mail/features/mailbox/data/mailbox_repository_impl.dart';
+import 'package:finestar_mail/features/mailbox/domain/entities/mail_conversation.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_folder.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_attachment.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -585,6 +586,116 @@ void main() {
       ]),
     );
   });
+
+  test(
+    'mailbox repository maps unified conversations and caches timeline messages',
+    () async {
+      final database = db.AppDatabase.forTesting(NativeDatabase.memory());
+      final storage = _MemorySecureStorageService();
+      addTearDown(database.close);
+      await storage.saveAuthToken(
+        accountId: 'app-test-1@finestar.hr',
+        token: 'backend-token',
+      );
+
+      final repository = MailboxRepositoryImpl(
+        appDatabase: database,
+        secureStorageService: storage,
+        backendMailApiClient: BackendMailApiClient(
+          httpClient: MockClient((request) async {
+            expect(request.url.path, '/api/mail/unified-conversations');
+            expect(request.url.queryParameters, {'limit': '50'});
+            return http.Response(
+              jsonEncode({
+                'account_email': 'app-test-1@finestar.hr',
+                'folders': [
+                  {'name': 'INBOX', 'path': 'INBOX'},
+                  {'name': 'Sent', 'path': 'Sent'},
+                ],
+                'conversations': [
+                  {
+                    'conversation_id': 'thread-1',
+                    'message_count': 2,
+                    'reply_count': 1,
+                    'has_unread': true,
+                    'has_attachments': true,
+                    'has_visible_attachments': true,
+                    'participants': [
+                      {'name': 'Client', 'email': 'client@example.test'},
+                    ],
+                    'latest_date': '2026-04-17T10:00:00Z',
+                    'messages': [
+                      {
+                        'uid': '40',
+                        'folder': 'INBOX',
+                        'direction': 'inbound',
+                        'subject': 'Conversation root',
+                        'sender': 'Client <client@example.test>',
+                        'to': ['app-test-1@finestar.hr'],
+                        'cc': [],
+                        'date': '2026-04-17T08:00:00Z',
+                        'message_id': '<root@example.test>',
+                        'flags': [],
+                        'size': 123,
+                        'has_attachments': false,
+                        'has_visible_attachments': false,
+                      },
+                      {
+                        'uid': '41',
+                        'folder': 'Sent',
+                        'direction': 'outbound',
+                        'subject': 'Re: Conversation root',
+                        'sender': 'app-test-1@finestar.hr',
+                        'to': ['client@example.test'],
+                        'cc': [],
+                        'date': '2026-04-17T10:00:00Z',
+                        'message_id': '<reply@example.test>',
+                        'flags': ['Seen'],
+                        'size': 456,
+                        'has_attachments': true,
+                        'has_visible_attachments': true,
+                      },
+                    ],
+                  },
+                ],
+              }),
+              200,
+            );
+          }),
+          baseUrlLoader: () async => 'https://mail.example.test',
+        ),
+      );
+
+      final conversations = await repository.getUnifiedConversations(
+        accountId: 'app-test-1@finestar.hr',
+      );
+
+      expect(conversations.single.id, 'thread-1');
+      expect(
+        conversations.single.messages.first.message.id,
+        endsWith(':api:40'),
+      );
+      expect(
+        conversations.single.messages.last.message.id,
+        contains(':sent:api:41'),
+      );
+      expect(
+        conversations.single.messages.last.direction,
+        MailConversationDirection.outbound,
+      );
+      expect(conversations.single.hasUnread, isTrue);
+      expect(conversations.single.hasVisibleAttachments, isTrue);
+
+      final cachedRows = await database.select(database.messageSummaries).get();
+      expect(
+        cachedRows.map((row) => row.id),
+        containsAll([
+          'app-test-1@finestar.hr:inbox:api:40',
+          'app-test-1@finestar.hr:sent:api:41',
+        ]),
+      );
+    },
+  );
 
   test(
     'mailbox repository moves backend messages to trash and removes cache rows',

--- a/test/mailbox_screen_test.dart
+++ b/test/mailbox_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:finestar_mail/features/auth/domain/entities/mail_account.dart';
 import 'package:finestar_mail/features/auth/presentation/auth_controller.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_delete_result.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_folder.dart';
+import 'package:finestar_mail/features/mailbox/domain/entities/mail_conversation.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_attachment.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_detail.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_page.dart';
@@ -153,6 +154,53 @@ void main() {
     expect(find.byIcon(Icons.attach_file), findsOneWidget);
   });
 
+  testWidgets('unified conversation renders outbound row and opens exact row', (
+    tester,
+  ) async {
+    final repository = _FakeMailboxRepository(
+      unifiedConversations: [_unifiedConversation],
+    );
+    await tester.pumpWidget(_buildTestApp(repository: repository));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Unified root'), findsOneWidget);
+    expect(find.text('Unified sent reply'), findsOneWidget);
+    expect(find.text('Sent'), findsOneWidget);
+    expect(find.byIcon(Icons.attach_file), findsOneWidget);
+
+    await tester.tap(find.text('Unified sent reply'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('detail:unified-sent-1'), findsOneWidget);
+  });
+
+  testWidgets('unified conversation reply selection targets reply row', (
+    tester,
+  ) async {
+    final repository = _FakeMailboxRepository(
+      unifiedConversations: [_unifiedConversation],
+    );
+    await tester.pumpWidget(_buildTestApp(repository: repository));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.descendant(
+        of: find.ancestor(
+          of: find.text('Unified sent reply'),
+          matching: find.byType(ListTile),
+        ),
+        matching: find.byType(CircleAvatar),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('1 selected'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Move selected to Trash'));
+    await tester.pumpAndSettle();
+
+    expect(repository.deletedMessageIds, ['unified-sent-1']);
+  });
+
   testWidgets('avatar opens account management route', (tester) async {
     await tester.pumpWidget(_buildTestApp());
     await tester.pumpAndSettle();
@@ -204,7 +252,7 @@ void main() {
     expect(repository.messages.first.isRead, isTrue);
   });
 
-  testWidgets('scrolling near bottom appends older messages once', (
+  testWidgets('unified inbox list does not request flat cursor pagination', (
     tester,
   ) async {
     final repository = _FakeMailboxRepository(initialMessageCount: 24);
@@ -216,11 +264,8 @@ void main() {
     await tester.drag(find.byType(ListView).last, const Offset(0, -2500));
     await tester.pumpAndSettle();
 
-    expect(find.text('Older backend page'), findsOneWidget);
-    expect(
-      repository.pageRequests.where((cursor) => cursor == '2'),
-      hasLength(1),
-    );
+    expect(find.text('Older backend page'), findsNothing);
+    expect(repository.pageRequests, isEmpty);
   });
 
   test('mailbox controller prevents duplicate concurrent load more', () async {
@@ -310,6 +355,12 @@ Widget _buildTestApp({_FakeMailboxRepository? repository}) {
         builder: (context, state) =>
             const Scaffold(body: Center(child: Text('Manage your account'))),
       ),
+      GoRoute(
+        path: AppRoute.messageDetail.path,
+        builder: (context, state) => Scaffold(
+          body: Center(child: Text('detail:${state.pathParameters['id']}')),
+        ),
+      ),
     ],
   );
 
@@ -346,57 +397,108 @@ const _inboxFolder = MailFolder(
   isInbox: true,
 );
 
+final _unifiedRoot = MailMessageSummary(
+  id: 'unified-root-1',
+  folderId: 'app-test-2@finestar.hr:inbox',
+  subject: 'Unified root',
+  sender: 'client@finestar.hr',
+  preview: 'Unified root preview',
+  receivedAt: DateTime(2026, 4, 16, 8),
+  isRead: false,
+  hasAttachments: false,
+  sequence: 30,
+);
+
+final _unifiedSentReply = MailMessageSummary(
+  id: 'unified-sent-1',
+  folderId: 'app-test-2@finestar.hr:sent',
+  subject: 'Unified sent reply',
+  sender: 'app-test-2@finestar.hr',
+  preview: 'Outbound reply preview',
+  receivedAt: DateTime(2026, 4, 16, 9),
+  isRead: true,
+  hasAttachments: false,
+  sequence: 31,
+);
+
+final _unifiedConversation = MailConversation(
+  id: 'unified-conversation-1',
+  messageCount: 2,
+  replyCount: 1,
+  hasUnread: true,
+  hasAttachments: true,
+  hasVisibleAttachments: true,
+  participants: const [
+    MailConversationParticipant(name: 'Client', email: 'client@finestar.hr'),
+  ],
+  messages: [
+    MailConversationMessage(
+      message: _unifiedRoot,
+      direction: MailConversationDirection.inbound,
+    ),
+    MailConversationMessage(
+      message: _unifiedSentReply,
+      direction: MailConversationDirection.outbound,
+    ),
+  ],
+  latestDate: DateTime(2026, 4, 16, 9),
+);
+
 class _FakeMailboxRepository implements MailboxRepository {
-  _FakeMailboxRepository({int initialMessageCount = 2, bool backendIds = false})
-    : messages = [
-        MailMessageSummary(
-          id: backendIds
-              ? 'app-test-2@finestar.hr:inbox:api:2'
-              : 'app-test-2@finestar.hr:inbox:imap:2',
-          folderId: 'app-test-2@finestar.hr:inbox',
-          subject: 'Pinned important',
-          sender: 'client@finestar.hr',
-          preview: 'Pinned unread message',
-          receivedAt: DateTime(2026, 4, 16, 8),
-          isRead: false,
-          isImportant: true,
-          isPinned: true,
-          hasAttachments: true,
-          sequence: 2,
-        ),
-        MailMessageSummary(
-          id: backendIds
-              ? 'app-test-2@finestar.hr:inbox:api:3'
-              : 'app-test-2@finestar.hr:inbox:imap:3',
-          folderId: 'app-test-2@finestar.hr:inbox',
-          subject: 'Read normal',
-          sender: 'team@finestar.hr',
-          preview: 'Regular read message',
-          receivedAt: DateTime(2026, 4, 16, 9),
-          isRead: true,
-          hasAttachments: false,
-          sequence: 3,
-        ),
-        for (var index = 4; index < initialMessageCount + 2; index++)
-          MailMessageSummary(
-            id: 'app-test-2@finestar.hr:inbox:imap:$index',
-            folderId: 'app-test-2@finestar.hr:inbox',
-            subject: 'Inbox message $index',
-            sender: 'team@finestar.hr',
-            preview: 'Extra message $index',
-            receivedAt: DateTime(
-              2026,
-              4,
-              16,
-              9,
-            ).subtract(Duration(minutes: index)),
-            isRead: true,
-            hasAttachments: false,
-            sequence: index,
-          ),
-      ];
+  _FakeMailboxRepository({
+    int initialMessageCount = 2,
+    bool backendIds = false,
+    this.unifiedConversations,
+  }) : messages = [
+         MailMessageSummary(
+           id: backendIds
+               ? 'app-test-2@finestar.hr:inbox:api:2'
+               : 'app-test-2@finestar.hr:inbox:imap:2',
+           folderId: 'app-test-2@finestar.hr:inbox',
+           subject: 'Pinned important',
+           sender: 'client@finestar.hr',
+           preview: 'Pinned unread message',
+           receivedAt: DateTime(2026, 4, 16, 8),
+           isRead: false,
+           isImportant: true,
+           isPinned: true,
+           hasAttachments: true,
+           sequence: 2,
+         ),
+         MailMessageSummary(
+           id: backendIds
+               ? 'app-test-2@finestar.hr:inbox:api:3'
+               : 'app-test-2@finestar.hr:inbox:imap:3',
+           folderId: 'app-test-2@finestar.hr:inbox',
+           subject: 'Read normal',
+           sender: 'team@finestar.hr',
+           preview: 'Regular read message',
+           receivedAt: DateTime(2026, 4, 16, 9),
+           isRead: true,
+           hasAttachments: false,
+           sequence: 3,
+         ),
+         for (var index = 4; index < initialMessageCount + 2; index++)
+           MailMessageSummary(
+             id: 'app-test-2@finestar.hr:inbox:imap:$index',
+             folderId: 'app-test-2@finestar.hr:inbox',
+             subject: 'Inbox message $index',
+             sender: 'team@finestar.hr',
+             preview: 'Extra message $index',
+             receivedAt: DateTime(
+               2026,
+               4,
+               16,
+               9,
+             ).subtract(Duration(minutes: index)),
+             isRead: true,
+             hasAttachments: false,
+             sequence: index,
+           ),
+       ];
 
   final List<MailMessageSummary> messages;
+  final List<MailConversation>? unifiedConversations;
   final trashMessages = <MailMessageSummary>[
     MailMessageSummary(
       id: 'app-test-2@finestar.hr:trash:api:2',
@@ -486,6 +588,39 @@ class _FakeMailboxRepository implements MailboxRepository {
     int pageSize = 20,
     bool forceRefresh = false,
   }) async => const [];
+
+  @override
+  Future<List<MailConversation>> getUnifiedConversations({
+    required String accountId,
+    int limit = 50,
+    bool forceRefresh = false,
+  }) async {
+    if (unifiedConversations != null) {
+      return unifiedConversations!;
+    }
+    return messages
+        .map(
+          (message) => MailConversation(
+            id: message.id,
+            messageCount: 1,
+            replyCount: 0,
+            hasUnread: !message.isRead,
+            hasAttachments: message.hasAttachments,
+            hasVisibleAttachments: message.hasAttachments,
+            participants: [
+              MailConversationParticipant(name: '', email: message.sender),
+            ],
+            messages: [
+              MailConversationMessage(
+                message: message,
+                direction: MailConversationDirection.inbound,
+              ),
+            ],
+            latestDate: message.receivedAt,
+          ),
+        )
+        .toList();
+  }
 
   @override
   Future<List<MailMessageSummary>> getMessages({

--- a/test/message_detail_screen_test.dart
+++ b/test/message_detail_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:finestar_mail/features/auth/presentation/auth_controller.dart';
 import 'package:finestar_mail/features/compose/domain/entities/reply_context.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_delete_result.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_folder.dart';
+import 'package:finestar_mail/features/mailbox/domain/entities/mail_conversation.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_attachment.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_detail.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_page.dart';
@@ -768,6 +769,13 @@ class _FakeMailboxRepository implements MailboxRepository {
     required String accountId,
     int page = 0,
     int pageSize = 20,
+    bool forceRefresh = false,
+  }) async => const [];
+
+  @override
+  Future<List<MailConversation>> getUnifiedConversations({
+    required String accountId,
+    int limit = 50,
     bool forceRefresh = false,
   }) async => const [];
 

--- a/test/notification_mail_sync_service_test.dart
+++ b/test/notification_mail_sync_service_test.dart
@@ -2,6 +2,7 @@ import 'package:finestar_mail/features/auth/domain/entities/connection_settings.
 import 'package:finestar_mail/features/auth/domain/entities/mail_account.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_delete_result.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_folder.dart';
+import 'package:finestar_mail/features/mailbox/domain/entities/mail_conversation.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_attachment.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_detail.dart';
 import 'package:finestar_mail/features/mailbox/domain/entities/mail_message_page.dart';
@@ -115,6 +116,13 @@ class _FakeMailboxRepository implements MailboxRepository {
     }
     return const [];
   }
+
+  @override
+  Future<List<MailConversation>> getUnifiedConversations({
+    required String accountId,
+    int limit = 50,
+    bool forceRefresh = false,
+  }) async => const [];
 
   @override
   Future<String?> findCachedMessageId({


### PR DESCRIPTION
## Summary
- Adds Flutter API/domain support for `/api/mail/unified-conversations`.
- Renders the default Inbox mailbox as backend-provided unified conversation timelines with inbound/outbound rows.
- Keeps detail routing row-specific by caching and opening each message by its own `folder + uid`.
- Leaves search and explicit non-Inbox folders on the existing flat mailbox path.

## Validation
- `flutter analyze`
- `flutter test test/mailbox_screen_test.dart test/backend_mail_api_client_test.dart test/backend_repository_migration_test.dart`
- `flutter build apk --debug`

Closes #62