### PR TITLE
Redesign conversation thread rows

### DIFF
--- a/lib/features/mailbox/presentation/mailbox_screen.dart
+++ b/lib/features/mailbox/presentation/mailbox_screen.dart
@@ -5,7 +5,6 @@ import 'package:finestar_mail/core/widgets/state_views.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import '../../../app/providers.dart';
 import '../../../app/router/app_route.dart';
@@ -15,6 +14,8 @@ import '../domain/entities/mail_conversation.dart';
 import '../domain/entities/mail_folder.dart';
 import '../domain/entities/mail_message_summary.dart';
 import 'mailbox_controller.dart';
+import 'widgets/conversation_card.dart';
+import 'widgets/message_list_tile.dart';
 
 class MailboxScreen extends ConsumerStatefulWidget {
   const MailboxScreen({super.key});
@@ -938,59 +939,13 @@ class _ConversationList extends ConsumerWidget {
         for (final conversation in conversations)
           Padding(
             padding: const EdgeInsets.only(bottom: 10),
-            child: SectionCard(
-              color: conversation.messages.any(
-                    (message) => selectedMessageIds.contains(message.message.id),
-                  )
-                  ? const Color(0xFFD7EAFE)
-                  : conversation.hasUnread
-                  ? const Color(0xFFEAF4FF)
-                  : Colors.white,
-              padding: const EdgeInsets.all(0),
-              child: Column(
-                children: [
-                  for (
-                    var index = 0;
-                    index < conversation.messages.length;
-                    index++
-                  )
-                    if (index == 0)
-                      _MessageListTile(
-                        message: conversation.messages[index].message,
-                        folder: folder,
-                        selected: selectedMessageIds.contains(
-                          conversation.messages[index].message.id,
-                        ),
-                        selectionEnabled: true,
-                        selectionActive: selectedMessageIds.isNotEmpty,
-                        onToggleSelected: onToggleSelected,
-                        onShowActions: _showMessageActions,
-                        hasAttachments: conversation.hasVisibleAttachments,
-                        isUnread: conversation.hasUnread,
-                        isImportant:
-                            conversation.messages[index].message.isImportant,
-                        isPinned: conversation.messages[index].message.isPinned,
-                        replyCount: conversation.replyCount,
-                        direction: conversation.messages[index].direction,
-                      )
-                    else
-                      _ThreadReplyRow(
-                        isLast: index == conversation.messages.length - 1,
-                        child: _MessageListTile(
-                          message: conversation.messages[index].message,
-                          folder: folder,
-                          selected: selectedMessageIds.contains(
-                            conversation.messages[index].message.id,
-                          ),
-                          selectionEnabled: true,
-                          selectionActive: selectedMessageIds.isNotEmpty,
-                          onToggleSelected: onToggleSelected,
-                          onShowActions: _showMessageActions,
-                          direction: conversation.messages[index].direction,
-                        ),
-                      ),
-                ],
-              ),
+            child: ConversationCard(
+              conversation: conversation,
+              folder: folder,
+              selectedMessageIds: selectedMessageIds,
+              selectionActive: selectedMessageIds.isNotEmpty,
+              onToggleSelected: onToggleSelected,
+              onShowActions: _showMessageActions,
             ),
           ),
       ],
@@ -1008,34 +963,6 @@ class _ConversationList extends ConsumerWidget {
       ref: ref,
       message: message,
       folder: folder,
-    );
-  }
-}
-
-class _ThreadReplyRow extends StatelessWidget {
-  const _ThreadReplyRow({required this.isLast, required this.child});
-
-  final bool isLast;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SizedBox(
-          width: 42,
-          child: Align(
-            alignment: Alignment.topCenter,
-            child: Container(
-              width: 2,
-              height: isLast ? 58 : 92,
-              color: const Color(0xFFDADCE0),
-            ),
-          ),
-        ),
-        Expanded(child: child),
-      ],
     );
   }
 }
@@ -1070,7 +997,7 @@ class _MessageList extends ConsumerWidget {
                 ? Colors.white
                 : const Color(0xFFEAF4FF),
             padding: const EdgeInsets.all(0),
-            child: _MessageListTile(
+            child: MailMessageListTile(
               message: message,
               folder: folder,
               selected: selected,
@@ -1097,183 +1024,6 @@ class _MessageList extends ConsumerWidget {
       message: message,
       folder: folder,
     );
-  }
-}
-
-class _MessageListTile extends StatelessWidget {
-  const _MessageListTile({
-    required this.message,
-    required this.folder,
-    required this.selected,
-    required this.selectionEnabled,
-    required this.selectionActive,
-    required this.onToggleSelected,
-    required this.onShowActions,
-    this.hasAttachments,
-    this.isUnread,
-    this.isImportant,
-    this.isPinned,
-    this.replyCount = 0,
-    this.direction = MailConversationDirection.inbound,
-  });
-
-  final MailMessageSummary message;
-  final MailFolder folder;
-  final bool selected;
-  final bool selectionEnabled;
-  final bool selectionActive;
-  final ValueChanged<String> onToggleSelected;
-  final Future<void> Function({
-    required BuildContext context,
-    required WidgetRef ref,
-    required MailMessageSummary message,
-    required MailFolder folder,
-  })
-  onShowActions;
-  final bool? hasAttachments;
-  final bool? isUnread;
-  final bool? isImportant;
-  final bool? isPinned;
-  final int replyCount;
-  final MailConversationDirection direction;
-
-  @override
-  Widget build(BuildContext context) {
-    final formatter = DateFormat('MMM d');
-    final effectiveUnread = isUnread ?? !message.isRead;
-    final effectiveImportant = isImportant ?? message.isImportant;
-    final effectivePinned = isPinned ?? message.isPinned;
-    final effectiveHasAttachments = hasAttachments ?? message.hasAttachments;
-    final isOutbound = direction == MailConversationDirection.outbound;
-
-    return Consumer(
-      builder: (context, ref, child) {
-        return ListTile(
-          onLongPress: () => onShowActions(
-            context: context,
-            ref: ref,
-            message: message,
-            folder: folder,
-          ),
-          onTap: selectionActive && selectionEnabled
-              ? () => onToggleSelected(message.id)
-              : () => context.push(
-                  AppRoute.messageDetail.path.replaceFirst(':id', message.id),
-                ),
-          contentPadding: const EdgeInsets.symmetric(
-            horizontal: 16,
-            vertical: 10,
-          ),
-          leading: Tooltip(
-            message: 'Select message',
-            child: InkWell(
-              customBorder: const CircleBorder(),
-              onTap: selectionEnabled
-                  ? () => onToggleSelected(message.id)
-                  : null,
-              child: CircleAvatar(
-                backgroundColor: selected
-                    ? Theme.of(context).colorScheme.primary
-                    : const Color(0xFFE8EFF8),
-                child: selected
-                    ? const Icon(Icons.check, color: Colors.white, size: 20)
-                    : Text(
-                        _senderInitial(message.sender),
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.primary,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-              ),
-            ),
-          ),
-          title: Row(
-            children: [
-              if (isOutbound) ...[
-                const Icon(Icons.send_outlined, size: 15),
-                const SizedBox(width: 5),
-                Text(
-                  'Sent',
-                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    color: const Color(0xFF2563A8),
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(width: 8),
-              ],
-              Expanded(
-                child: Text(
-                  message.subject,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontWeight: effectiveUnread
-                        ? FontWeight.w800
-                        : FontWeight.w500,
-                  ),
-                ),
-              ),
-              if (replyCount > 0) ...[
-                const SizedBox(width: 8),
-                Text(
-                  '$replyCount replies',
-                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                    color: const Color(0xFF5F6368),
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ],
-            ],
-          ),
-          subtitle: Padding(
-            padding: const EdgeInsets.only(top: 4),
-            child: Text(
-              '${message.sender}\n${message.preview}',
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          trailing: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Text(formatter.format(message.receivedAt)),
-              const SizedBox(height: 6),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (effectiveImportant)
-                    const Icon(Icons.error, size: 16, color: Color(0xFFD93025)),
-                  if (effectivePinned)
-                    const Padding(
-                      padding: EdgeInsets.only(left: 4),
-                      child: Icon(
-                        Icons.push_pin,
-                        size: 16,
-                        color: Color(0xFF153B52),
-                      ),
-                    ),
-                  if (effectiveHasAttachments)
-                    const Padding(
-                      padding: EdgeInsets.only(left: 4),
-                      child: Icon(Icons.attach_file, size: 16),
-                    ),
-                ],
-              ),
-            ],
-          ),
-          isThreeLine: true,
-        );
-      },
-    );
-  }
-
-  String _senderInitial(String sender) {
-    final trimmed = sender.trim();
-    if (trimmed.isEmpty) {
-      return '?';
-    }
-    return trimmed.characters.first.toUpperCase();
   }
 }
 

--- a/lib/features/mailbox/presentation/widgets/conversation_card.dart
+++ b/lib/features/mailbox/presentation/widgets/conversation_card.dart
@@ -1,0 +1,237 @@
+import 'package:finestar_mail/core/widgets/section_card.dart';
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/mail_conversation.dart';
+import '../../domain/entities/mail_folder.dart';
+import '../../domain/entities/mail_message_summary.dart';
+import 'conversation_display_helpers.dart';
+import 'message_list_tile.dart';
+
+class ConversationCard extends StatelessWidget {
+  const ConversationCard({
+    super.key,
+    required this.conversation,
+    required this.folder,
+    required this.selectedMessageIds,
+    required this.selectionActive,
+    required this.onToggleSelected,
+    required this.onShowActions,
+  });
+
+  final MailConversation conversation;
+  final MailFolder folder;
+  final Set<String> selectedMessageIds;
+  final bool selectionActive;
+  final ValueChanged<String> onToggleSelected;
+  final MessageActionCallback onShowActions;
+
+  @override
+  Widget build(BuildContext context) {
+    final messages = conversationTimelinePreview(conversation);
+    return SectionCard(
+      color:
+          messages.any(
+            (message) => selectedMessageIds.contains(message.message.id),
+          )
+          ? const Color(0xFFD7EAFE)
+          : conversation.hasUnread
+          ? const Color(0xFFEAF4FF)
+          : Colors.white,
+      padding: const EdgeInsets.all(0),
+      child: ConversationTimeline(
+        conversation: conversation,
+        messages: messages,
+        folder: folder,
+        selectedMessageIds: selectedMessageIds,
+        selectionActive: selectionActive,
+        onToggleSelected: onToggleSelected,
+        onShowActions: onShowActions,
+      ),
+    );
+  }
+}
+
+class ConversationTimeline extends StatelessWidget {
+  const ConversationTimeline({
+    super.key,
+    required this.conversation,
+    required this.messages,
+    required this.folder,
+    required this.selectedMessageIds,
+    required this.selectionActive,
+    required this.onToggleSelected,
+    required this.onShowActions,
+  });
+
+  final MailConversation conversation;
+  final List<MailConversationMessage> messages;
+  final MailFolder folder;
+  final Set<String> selectedMessageIds;
+  final bool selectionActive;
+  final ValueChanged<String> onToggleSelected;
+  final MessageActionCallback onShowActions;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (var index = 0; index < messages.length; index++)
+          ConversationTimelineItem(
+            conversation: conversation,
+            item: messages[index],
+            folder: folder,
+            selected: selectedMessageIds.contains(messages[index].message.id),
+            selectionActive: selectionActive,
+            onToggleSelected: onToggleSelected,
+            onShowActions: onShowActions,
+            isRoot: index == 0,
+            isLast: index == messages.length - 1,
+            isLatestInConversation: index == messages.length - 1,
+          ),
+      ],
+    );
+  }
+}
+
+class ConversationTimelineItem extends StatelessWidget {
+  const ConversationTimelineItem({
+    super.key,
+    required this.conversation,
+    required this.item,
+    required this.folder,
+    required this.selected,
+    required this.selectionActive,
+    required this.onToggleSelected,
+    required this.onShowActions,
+    required this.isRoot,
+    required this.isLast,
+    required this.isLatestInConversation,
+  });
+
+  final MailConversation conversation;
+  final MailConversationMessage item;
+  final MailFolder folder;
+  final bool selected;
+  final bool selectionActive;
+  final ValueChanged<String> onToggleSelected;
+  final MessageActionCallback onShowActions;
+  final bool isRoot;
+  final bool isLast;
+  final bool isLatestInConversation;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = item.message;
+    final tile = MailMessageListTile(
+      message: message,
+      folder: folder,
+      selected: selected,
+      selectionEnabled: true,
+      selectionActive: selectionActive,
+      onToggleSelected: onToggleSelected,
+      onShowActions: onShowActions,
+      hasAttachments: isRoot ? conversation.hasVisibleAttachments : null,
+      isUnread: isRoot ? conversation.hasUnread : null,
+      isImportant: isRoot ? message.isImportant : null,
+      isPinned: isRoot ? message.isPinned : null,
+      replyCount: isRoot ? conversation.replyCount : 0,
+      direction: item.direction,
+      displaySubject: displayConversationSubject(message.subject),
+      showOutboundBadge: true,
+      isLatestInConversation: isLatestInConversation,
+      title: isRoot
+          ? ConversationHeader(
+              conversation: conversation,
+              message: message,
+              direction: item.direction,
+              isLatestInConversation: isLatestInConversation,
+            )
+          : null,
+    );
+
+    if (isRoot) {
+      return tile;
+    }
+
+    return _ThreadReplyRow(isLast: isLast, child: tile);
+  }
+}
+
+class ConversationHeader extends StatelessWidget {
+  const ConversationHeader({
+    super.key,
+    required this.conversation,
+    required this.message,
+    required this.direction,
+    required this.isLatestInConversation,
+  });
+
+  final MailConversation conversation;
+  final MailMessageSummary message;
+  final MailConversationDirection direction;
+  final bool isLatestInConversation;
+
+  @override
+  Widget build(BuildContext context) {
+    final isOutbound = direction == MailConversationDirection.outbound;
+
+    return Row(
+      children: [
+        if (isOutbound) ...[
+          const OutboundMessageBadge(),
+          const SizedBox(width: 8),
+        ],
+        Expanded(
+          child: Text(
+            displayConversationSubject(message.subject),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontWeight: conversation.hasUnread || isLatestInConversation
+                  ? FontWeight.w800
+                  : FontWeight.w500,
+            ),
+          ),
+        ),
+        if (conversation.replyCount > 0) ...[
+          const SizedBox(width: 8),
+          Text(
+            '${conversation.replyCount} replies',
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: const Color(0xFF5F6368),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _ThreadReplyRow extends StatelessWidget {
+  const _ThreadReplyRow({required this.isLast, required this.child});
+
+  final bool isLast;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 42,
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: Container(
+              width: 2,
+              height: isLast ? 58 : 92,
+              color: const Color(0xFFDADCE0),
+            ),
+          ),
+        ),
+        Expanded(child: child),
+      ],
+    );
+  }
+}

--- a/lib/features/mailbox/presentation/widgets/conversation_display_helpers.dart
+++ b/lib/features/mailbox/presentation/widgets/conversation_display_helpers.dart
@@ -1,0 +1,24 @@
+import '../../domain/entities/mail_conversation.dart';
+
+String displayConversationSubject(String subject) {
+  final original = subject.trim();
+  if (original.isEmpty) {
+    return '(No subject)';
+  }
+
+  var display = original;
+  var previous = '';
+  final prefixPattern = RegExp(r'^(re|fw|fwd):\s*', caseSensitive: false);
+  while (display != previous) {
+    previous = display;
+    display = display.replaceFirst(prefixPattern, '').trimLeft();
+  }
+
+  return display.trim().isEmpty ? original : display.trim();
+}
+
+List<MailConversationMessage> conversationTimelinePreview(
+  MailConversation conversation,
+) {
+  return conversation.messages;
+}

--- a/lib/features/mailbox/presentation/widgets/message_list_tile.dart
+++ b/lib/features/mailbox/presentation/widgets/message_list_tile.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../app/router/app_route.dart';
+import '../../domain/entities/mail_conversation.dart';
+import '../../domain/entities/mail_folder.dart';
+import '../../domain/entities/mail_message_summary.dart';
+
+typedef MessageActionCallback =
+    Future<void> Function({
+      required BuildContext context,
+      required WidgetRef ref,
+      required MailMessageSummary message,
+      required MailFolder folder,
+    });
+
+class MailMessageListTile extends StatelessWidget {
+  const MailMessageListTile({
+    super.key,
+    required this.message,
+    required this.folder,
+    required this.selected,
+    required this.selectionEnabled,
+    required this.selectionActive,
+    required this.onToggleSelected,
+    required this.onShowActions,
+    this.hasAttachments,
+    this.isUnread,
+    this.isImportant,
+    this.isPinned,
+    this.replyCount = 0,
+    this.direction = MailConversationDirection.inbound,
+    this.displaySubject,
+    this.title,
+    this.showOutboundBadge = false,
+    this.isLatestInConversation = false,
+  });
+
+  final MailMessageSummary message;
+  final MailFolder folder;
+  final bool selected;
+  final bool selectionEnabled;
+  final bool selectionActive;
+  final ValueChanged<String> onToggleSelected;
+  final MessageActionCallback onShowActions;
+  final bool? hasAttachments;
+  final bool? isUnread;
+  final bool? isImportant;
+  final bool? isPinned;
+  final int replyCount;
+  final MailConversationDirection direction;
+  final String? displaySubject;
+  final Widget? title;
+  final bool showOutboundBadge;
+  final bool isLatestInConversation;
+
+  @override
+  Widget build(BuildContext context) {
+    final formatter = DateFormat('MMM d');
+    final effectiveUnread = isUnread ?? !message.isRead;
+    final effectiveImportant = isImportant ?? message.isImportant;
+    final effectivePinned = isPinned ?? message.isPinned;
+    final effectiveHasAttachments = hasAttachments ?? message.hasAttachments;
+
+    return Consumer(
+      builder: (context, ref, child) {
+        return ListTile(
+          key: isLatestInConversation
+              ? ValueKey('latest-conversation-message-${message.id}')
+              : null,
+          onLongPress: () => onShowActions(
+            context: context,
+            ref: ref,
+            message: message,
+            folder: folder,
+          ),
+          onTap: selectionActive && selectionEnabled
+              ? () => onToggleSelected(message.id)
+              : () => context.push(
+                  AppRoute.messageDetail.path.replaceFirst(':id', message.id),
+                ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 10,
+          ),
+          leading: Tooltip(
+            message: 'Select message',
+            child: InkWell(
+              customBorder: const CircleBorder(),
+              onTap: selectionEnabled
+                  ? () => onToggleSelected(message.id)
+                  : null,
+              child: CircleAvatar(
+                backgroundColor: selected
+                    ? Theme.of(context).colorScheme.primary
+                    : const Color(0xFFE8EFF8),
+                child: selected
+                    ? const Icon(Icons.check, color: Colors.white, size: 20)
+                    : Text(
+                        _senderInitial(message.sender),
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.primary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+              ),
+            ),
+          ),
+          title:
+              title ??
+              _DefaultMessageTitle(
+                subject: displaySubject ?? message.subject,
+                isUnread: effectiveUnread,
+                replyCount: replyCount,
+                direction: direction,
+                showOutboundBadge: showOutboundBadge,
+                isLatestInConversation: isLatestInConversation,
+              ),
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              '${message.sender}\n${message.preview}',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: isLatestInConversation
+                  ? Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF3C4043),
+                      fontWeight: FontWeight.w600,
+                    )
+                  : null,
+            ),
+          ),
+          trailing: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(formatter.format(message.receivedAt)),
+              const SizedBox(height: 6),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (effectiveImportant)
+                    const Icon(Icons.error, size: 16, color: Color(0xFFD93025)),
+                  if (effectivePinned)
+                    const Padding(
+                      padding: EdgeInsets.only(left: 4),
+                      child: Icon(
+                        Icons.push_pin,
+                        size: 16,
+                        color: Color(0xFF153B52),
+                      ),
+                    ),
+                  if (effectiveHasAttachments)
+                    const Padding(
+                      padding: EdgeInsets.only(left: 4),
+                      child: Icon(Icons.attach_file, size: 16),
+                    ),
+                ],
+              ),
+            ],
+          ),
+          isThreeLine: true,
+        );
+      },
+    );
+  }
+
+  String _senderInitial(String sender) {
+    final trimmed = sender.trim();
+    if (trimmed.isEmpty) {
+      return '?';
+    }
+    return trimmed.characters.first.toUpperCase();
+  }
+}
+
+class _DefaultMessageTitle extends StatelessWidget {
+  const _DefaultMessageTitle({
+    required this.subject,
+    required this.isUnread,
+    required this.replyCount,
+    required this.direction,
+    required this.showOutboundBadge,
+    required this.isLatestInConversation,
+  });
+
+  final String subject;
+  final bool isUnread;
+  final int replyCount;
+  final MailConversationDirection direction;
+  final bool showOutboundBadge;
+  final bool isLatestInConversation;
+
+  @override
+  Widget build(BuildContext context) {
+    final showBadge =
+        showOutboundBadge && direction == MailConversationDirection.outbound;
+
+    return Row(
+      children: [
+        if (showBadge) ...[
+          const OutboundMessageBadge(),
+          const SizedBox(width: 8),
+        ],
+        Expanded(
+          child: Text(
+            subject,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontWeight: isUnread || isLatestInConversation
+                  ? FontWeight.w800
+                  : FontWeight.w500,
+            ),
+          ),
+        ),
+        if (replyCount > 0) ...[
+          const SizedBox(width: 8),
+          Text(
+            '$replyCount replies',
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: const Color(0xFF5F6368),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class OutboundMessageBadge extends StatelessWidget {
+  const OutboundMessageBadge({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFFEAF4FF),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: const Color(0xFFB7D7F8)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.send_outlined, size: 13, color: Color(0xFF2563A8)),
+            const SizedBox(width: 4),
+            Text(
+              'Sent',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: const Color(0xFF2563A8),
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/mailbox_screen_test.dart
+++ b/test/mailbox_screen_test.dart
@@ -154,6 +154,28 @@ void main() {
     expect(find.byIcon(Icons.attach_file), findsOneWidget);
   });
 
+  testWidgets('search results do not receive conversation-only styling', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildTestApp());
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'Pinned');
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pinned important'), findsOneWidget);
+    expect(find.text('Sent'), findsNothing);
+    expect(
+      find.byKey(
+        const ValueKey(
+          'latest-conversation-message-app-test-2@finestar.hr:inbox:imap:2',
+        ),
+      ),
+      findsNothing,
+    );
+  });
+
   testWidgets('mailbox renders backend conversations expanded by default', (
     tester,
   ) async {
@@ -167,9 +189,15 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Thread root'), findsOneWidget);
+    expect(find.text('Re: Fwd: Thread root'), findsNothing);
     expect(find.text('Thread reply one'), findsOneWidget);
     expect(find.text('Thread reply two'), findsOneWidget);
     expect(find.text('2 replies'), findsOneWidget);
+    expect(find.text('Sent'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('latest-conversation-message-reply-2')),
+      findsOneWidget,
+    );
     expect(
       tester.getTopLeft(find.text('Thread reply one')).dx,
       greaterThan(tester.getTopLeft(find.text('Thread root')).dx),
@@ -201,6 +229,10 @@ void main() {
     expect(find.text('Unified root'), findsOneWidget);
     expect(find.text('Unified sent reply'), findsOneWidget);
     expect(find.text('Sent'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('latest-conversation-message-unified-sent-1')),
+      findsOneWidget,
+    );
     expect(find.byIcon(Icons.attach_file), findsOneWidget);
 
     await tester.tap(find.text('Unified sent reply'));
@@ -433,7 +465,7 @@ const _inboxFolder = MailFolder(
 final _threadRoot = MailMessageSummary(
   id: 'root-1',
   folderId: 'app-test-2@finestar.hr:inbox',
-  subject: 'Thread root',
+  subject: 'Re: Fwd: Thread root',
   sender: 'client@finestar.hr',
   preview: 'Root preview',
   receivedAt: DateTime(2026, 4, 16, 8),
@@ -1001,5 +1033,16 @@ class _FakeMailboxRepository implements MailboxRepository {
     required MailFolder folder,
     required String query,
     int limit = 30,
-  }) async => const [];
+  }) async {
+    final normalizedQuery = query.toLowerCase();
+    return messages
+        .where(
+          (message) =>
+              message.subject.toLowerCase().contains(normalizedQuery) ||
+              message.sender.toLowerCase().contains(normalizedQuery) ||
+              message.preview.toLowerCase().contains(normalizedQuery),
+        )
+        .take(limit)
+        .toList();
+  }
 }


### PR DESCRIPTION
## Summary
- add conversation-only outbound `Sent` badge support via opt-in row flags
- add subtle latest-message emphasis for the last visible conversation item
- keep flat mailbox/search list rendering unchanged and covered by regression tests

## Testing
- `flutter test test/mailbox_screen_test.dart`
- `flutter analyze`
- `flutter test` *(still fails on the known unrelated Firebase init issue in `test/login_screen_test.dart`)*