### PR TITLE
[codex] Add conversation collapse controls

### DIFF
--- a/lib/features/mailbox/presentation/mailbox_screen.dart
+++ b/lib/features/mailbox/presentation/mailbox_screen.dart
@@ -815,6 +815,7 @@ class _MailboxContent extends ConsumerStatefulWidget {
 
 class _MailboxContentState extends ConsumerState<_MailboxContent> {
   final _scrollController = ScrollController();
+  final _expandedConversationIds = <String>{};
 
   @override
   void initState() {
@@ -829,8 +830,29 @@ class _MailboxContentState extends ConsumerState<_MailboxContent> {
     super.dispose();
   }
 
+  @override
+  void didUpdateWidget(covariant _MailboxContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.folder.id != widget.folder.id) {
+      _expandedConversationIds.clear();
+    }
+  }
+
   void _maybeLoadMore() {
     return;
+  }
+
+  bool _isConversationCollapsed(MailConversation conversation) {
+    return conversation.messages.length > 3 &&
+        !_expandedConversationIds.contains(conversation.id);
+  }
+
+  void _toggleConversationExpanded(String conversationId) {
+    setState(() {
+      if (!_expandedConversationIds.add(conversationId)) {
+        _expandedConversationIds.remove(conversationId);
+      }
+    });
   }
 
   @override
@@ -901,6 +923,8 @@ class _MailboxContentState extends ConsumerState<_MailboxContent> {
                 folder: folder,
                 selectedMessageIds: widget.selectedMessageIds,
                 onToggleSelected: widget.onToggleSelected,
+                isConversationCollapsed: _isConversationCollapsed,
+                onToggleConversationExpanded: _toggleConversationExpanded,
               );
             },
             error: (error, stackTrace) => ErrorStateView(
@@ -925,12 +949,16 @@ class _ConversationList extends ConsumerWidget {
     required this.folder,
     required this.selectedMessageIds,
     required this.onToggleSelected,
+    required this.isConversationCollapsed,
+    required this.onToggleConversationExpanded,
   });
 
   final List<MailConversation> conversations;
   final MailFolder folder;
   final Set<String> selectedMessageIds;
   final ValueChanged<String> onToggleSelected;
+  final bool Function(MailConversation conversation) isConversationCollapsed;
+  final ValueChanged<String> onToggleConversationExpanded;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -944,6 +972,9 @@ class _ConversationList extends ConsumerWidget {
               folder: folder,
               selectedMessageIds: selectedMessageIds,
               selectionActive: selectedMessageIds.isNotEmpty,
+              isCollapsed: isConversationCollapsed(conversation),
+              onToggleCollapsed: () =>
+                  onToggleConversationExpanded(conversation.id),
               onToggleSelected: onToggleSelected,
               onShowActions: _showMessageActions,
             ),

--- a/lib/features/mailbox/presentation/widgets/conversation_card.dart
+++ b/lib/features/mailbox/presentation/widgets/conversation_card.dart
@@ -14,6 +14,8 @@ class ConversationCard extends StatelessWidget {
     required this.folder,
     required this.selectedMessageIds,
     required this.selectionActive,
+    required this.isCollapsed,
+    required this.onToggleCollapsed,
     required this.onToggleSelected,
     required this.onShowActions,
   });
@@ -22,12 +24,15 @@ class ConversationCard extends StatelessWidget {
   final MailFolder folder;
   final Set<String> selectedMessageIds;
   final bool selectionActive;
+  final bool isCollapsed;
+  final VoidCallback onToggleCollapsed;
   final ValueChanged<String> onToggleSelected;
   final MessageActionCallback onShowActions;
 
   @override
   Widget build(BuildContext context) {
     final messages = conversationTimelinePreview(conversation);
+    final canCollapse = messages.length > 3;
     return SectionCard(
       color:
           messages.any(
@@ -41,6 +46,9 @@ class ConversationCard extends StatelessWidget {
       child: ConversationTimeline(
         conversation: conversation,
         messages: messages,
+        isCollapsed: canCollapse && isCollapsed,
+        showCollapseToggle: canCollapse,
+        onToggleCollapsed: onToggleCollapsed,
         folder: folder,
         selectedMessageIds: selectedMessageIds,
         selectionActive: selectionActive,
@@ -56,6 +64,9 @@ class ConversationTimeline extends StatelessWidget {
     super.key,
     required this.conversation,
     required this.messages,
+    required this.isCollapsed,
+    required this.showCollapseToggle,
+    required this.onToggleCollapsed,
     required this.folder,
     required this.selectedMessageIds,
     required this.selectionActive,
@@ -65,6 +76,9 @@ class ConversationTimeline extends StatelessWidget {
 
   final MailConversation conversation;
   final List<MailConversationMessage> messages;
+  final bool isCollapsed;
+  final bool showCollapseToggle;
+  final VoidCallback onToggleCollapsed;
   final MailFolder folder;
   final Set<String> selectedMessageIds;
   final bool selectionActive;
@@ -73,22 +87,100 @@ class ConversationTimeline extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final visibleItems = _visibleItems(messages, isCollapsed);
+
     return Column(
       children: [
-        for (var index = 0; index < messages.length; index++)
+        for (var index = 0; index < visibleItems.length; index++) ...[
+          if (index == 1 && showCollapseToggle)
+            ConversationCollapseToggle(
+              key: ValueKey('conversation-collapse-toggle-${conversation.id}'),
+              isCollapsed: isCollapsed,
+              hiddenMessageCount: _hiddenMessageCount(messages, isCollapsed),
+              onPressed: onToggleCollapsed,
+            ),
           ConversationTimelineItem(
             conversation: conversation,
-            item: messages[index],
+            item: visibleItems[index],
             folder: folder,
-            selected: selectedMessageIds.contains(messages[index].message.id),
+            selected: selectedMessageIds.contains(
+              visibleItems[index].message.id,
+            ),
             selectionActive: selectionActive,
             onToggleSelected: onToggleSelected,
             onShowActions: onShowActions,
-            isRoot: index == 0,
-            isLast: index == messages.length - 1,
-            isLatestInConversation: index == messages.length - 1,
+            isRoot: identical(visibleItems[index], messages.first),
+            isLast: index == visibleItems.length - 1,
+            isLatestInConversation:
+                visibleItems[index].message.id == messages.last.message.id,
+          ),
+        ],
+        if (showCollapseToggle && visibleItems.length <= 1)
+          ConversationCollapseToggle(
+            key: ValueKey('conversation-collapse-toggle-${conversation.id}'),
+            isCollapsed: isCollapsed,
+            hiddenMessageCount: _hiddenMessageCount(messages, isCollapsed),
+            onPressed: onToggleCollapsed,
           ),
       ],
+    );
+  }
+
+  List<MailConversationMessage> _visibleItems(
+    List<MailConversationMessage> messages,
+    bool isCollapsed,
+  ) {
+    if (!isCollapsed || messages.length <= 3) {
+      return messages;
+    }
+    if (messages.first.message.id == messages.last.message.id) {
+      return [messages.first];
+    }
+    return [messages.first, messages.last];
+  }
+
+  int _hiddenMessageCount(
+    List<MailConversationMessage> messages,
+    bool isCollapsed,
+  ) {
+    if (!isCollapsed || messages.length <= 3) {
+      return 0;
+    }
+    final visibleCount = messages.first.message.id == messages.last.message.id
+        ? 1
+        : 2;
+    return (messages.length - visibleCount).clamp(0, messages.length);
+  }
+}
+
+class ConversationCollapseToggle extends StatelessWidget {
+  const ConversationCollapseToggle({
+    super.key,
+    required this.isCollapsed,
+    required this.hiddenMessageCount,
+    required this.onPressed,
+  });
+
+  final bool isCollapsed;
+  final int hiddenMessageCount;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = isCollapsed ? 'Show $hiddenMessageCount more' : 'Show less';
+    return Padding(
+      padding: const EdgeInsets.only(left: 42),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: TextButton.icon(
+          onPressed: onPressed,
+          icon: Icon(
+            isCollapsed ? Icons.expand_more : Icons.expand_less,
+            size: 18,
+          ),
+          label: Text(label),
+        ),
+      ),
     );
   }
 }

--- a/test/mailbox_screen_test.dart
+++ b/test/mailbox_screen_test.dart
@@ -166,6 +166,7 @@ void main() {
 
     expect(find.text('Pinned important'), findsOneWidget);
     expect(find.text('Sent'), findsNothing);
+    expect(find.textContaining('Show '), findsNothing);
     expect(
       find.byKey(
         const ValueKey(
@@ -194,6 +195,7 @@ void main() {
     expect(find.text('Thread reply two'), findsOneWidget);
     expect(find.text('2 replies'), findsOneWidget);
     expect(find.text('Sent'), findsNothing);
+    expect(find.textContaining('Show '), findsNothing);
     expect(
       find.byKey(const ValueKey('latest-conversation-message-reply-2')),
       findsOneWidget,
@@ -202,6 +204,85 @@ void main() {
       tester.getTopLeft(find.text('Thread reply one')).dx,
       greaterThan(tester.getTopLeft(find.text('Thread root')).dx),
     );
+  });
+
+  testWidgets('long conversation collapses and expands without reordering', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildTestApp(
+        repository: _FakeMailboxRepository(
+          threadedConversations: [_longConversation],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Long root'), findsOneWidget);
+    expect(find.text('Long reply one'), findsNothing);
+    expect(find.text('Long reply two'), findsNothing);
+    expect(find.text('Long reply three'), findsNothing);
+    expect(find.text('Long reply four'), findsOneWidget);
+    expect(find.text('Show 3 more'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('latest-conversation-message-long-reply-4')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Show 3 more'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Long reply one'), findsOneWidget);
+    expect(find.text('Long reply two'), findsOneWidget);
+    expect(find.text('Long reply three'), findsOneWidget);
+    expect(find.text('Show less'), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.text('Long root')).dy,
+      lessThan(tester.getTopLeft(find.text('Long reply one')).dy),
+    );
+    expect(
+      tester.getTopLeft(find.text('Long reply one')).dy,
+      lessThan(tester.getTopLeft(find.text('Long reply two')).dy),
+    );
+    expect(
+      tester.getTopLeft(find.text('Long reply two')).dy,
+      lessThan(tester.getTopLeft(find.text('Long reply three')).dy),
+    );
+    expect(
+      tester.getTopLeft(find.text('Long reply three')).dy,
+      lessThan(tester.getTopLeft(find.text('Long reply four')).dy),
+    );
+
+    await tester.tap(find.text('Show less'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Long reply one'), findsNothing);
+    expect(find.text('Long reply four'), findsOneWidget);
+    expect(find.text('Show 3 more'), findsOneWidget);
+  });
+
+  testWidgets('expanded conversation state survives refresh', (tester) async {
+    await tester.pumpWidget(
+      _buildTestApp(
+        repository: _FakeMailboxRepository(
+          threadedConversations: [_longConversation],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Show 3 more'));
+    await tester.pumpAndSettle();
+    expect(find.text('Long reply two'), findsOneWidget);
+
+    await tester.drag(find.byType(ListView).last, const Offset(0, 420));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Long reply two'), findsOneWidget);
+    expect(find.text('Show less'), findsOneWidget);
+    expect(find.text('Show 3 more'), findsNothing);
   });
 
   testWidgets('conversation reply tap opens reply detail row', (tester) async {
@@ -558,6 +639,103 @@ final _unifiedConversation = MailConversation(
     ),
     MailConversationMessage(
       message: _unifiedSentReply,
+      direction: MailConversationDirection.outbound,
+    ),
+  ],
+);
+
+final _longRoot = MailMessageSummary(
+  id: 'long-root',
+  folderId: 'app-test-2@finestar.hr:inbox',
+  subject: 'Long root',
+  sender: 'client@finestar.hr',
+  preview: 'Long root preview',
+  receivedAt: DateTime(2026, 4, 16, 8),
+  isRead: true,
+  hasAttachments: false,
+  sequence: 40,
+);
+
+final _longReplyOne = MailMessageSummary(
+  id: 'long-reply-1',
+  folderId: 'app-test-2@finestar.hr:inbox',
+  subject: 'Long reply one',
+  sender: 'app-test-2@finestar.hr',
+  preview: 'Long reply one preview',
+  receivedAt: DateTime(2026, 4, 16, 9),
+  isRead: true,
+  hasAttachments: false,
+  sequence: 41,
+);
+
+final _longReplyTwo = MailMessageSummary(
+  id: 'long-reply-2',
+  folderId: 'app-test-2@finestar.hr:inbox',
+  subject: 'Long reply two',
+  sender: 'client@finestar.hr',
+  preview: 'Long reply two preview',
+  receivedAt: DateTime(2026, 4, 16, 10),
+  isRead: true,
+  hasAttachments: false,
+  sequence: 42,
+);
+
+final _longReplyThree = MailMessageSummary(
+  id: 'long-reply-3',
+  folderId: 'app-test-2@finestar.hr:inbox',
+  subject: 'Long reply three',
+  sender: 'client@finestar.hr',
+  preview: 'Long reply three preview',
+  receivedAt: DateTime(2026, 4, 16, 11),
+  isRead: true,
+  hasAttachments: false,
+  sequence: 43,
+);
+
+final _longReplyFour = MailMessageSummary(
+  id: 'long-reply-4',
+  folderId: 'app-test-2@finestar.hr:sent',
+  subject: 'Long reply four',
+  sender: 'app-test-2@finestar.hr',
+  preview: 'Long reply four preview',
+  receivedAt: DateTime(2026, 4, 16, 12),
+  isRead: true,
+  hasAttachments: false,
+  sequence: 44,
+);
+
+final _longConversation = MailConversation(
+  id: 'long-conversation',
+  messageCount: 5,
+  replyCount: 4,
+  hasUnread: false,
+  hasAttachments: false,
+  hasVisibleAttachments: false,
+  participants: const [
+    MailConversationParticipant(name: 'Client', email: 'client@finestar.hr'),
+  ],
+  rootMessage: _longRoot,
+  replies: [_longReplyOne, _longReplyTwo, _longReplyThree, _longReplyFour],
+  latestDate: DateTime(2026, 4, 16, 12),
+  timelineMessages: [
+    MailConversationMessage(
+      message: _longRoot,
+      direction: MailConversationDirection.inbound,
+    ),
+    MailConversationMessage(
+      message: _longReplyOne,
+      direction: MailConversationDirection.outbound,
+    ),
+    MailConversationMessage(
+      message: _longReplyTwo,
+      direction: MailConversationDirection.inbound,
+    ),
+    MailConversationMessage(
+      message: _longReplyThree,
+      direction: MailConversationDirection.inbound,
+    ),
+    MailConversationMessage(
+      message: _longReplyFour,
       direction: MailConversationDirection.outbound,
     ),
   ],


### PR DESCRIPTION
## Summary
- add conversation-only collapse/expand controls for long conversation threads
- keep conversations with 3 or fewer messages fully expanded
- preserve expanded state across list rebuilds and refreshes while the mailbox screen remains mounted

## Scope
- no backend/API changes
- no package changes
- no search result redesign
- no timeline rail or indentation redesign

## Validation
- `flutter test test\mailbox_screen_test.dart` passed
- `flutter analyze` passed
- `flutter test` still fails on the known unrelated Firebase initialization issue in `test/login_screen_test.dart`: `[core/no-app] No Firebase App '[DEFAULT]' has been created`

## Issue
- Part of #66, PR 3: collapse / expand only
