### PR TITLE
[codex] Add press-hold password reveal

### DIFF
--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -222,7 +222,7 @@ class _LoginCard extends StatelessWidget {
   }
 }
 
-class _LoginTextField extends StatelessWidget {
+class _LoginTextField extends StatefulWidget {
   const _LoginTextField({
     required this.controller,
     required this.labelText,
@@ -242,21 +242,49 @@ class _LoginTextField extends StatelessWidget {
   final ValueChanged<String>? onFieldSubmitted;
 
   @override
+  State<_LoginTextField> createState() => _LoginTextFieldState();
+}
+
+class _LoginTextFieldState extends State<_LoginTextField> {
+  var _isPasswordVisible = false;
+
+  @override
+  void didUpdateWidget(covariant _LoginTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!widget.obscureText && _isPasswordVisible) {
+      _hidePassword();
+    }
+  }
+
+  void _showPassword() {
+    if (!_isPasswordVisible) {
+      setState(() => _isPasswordVisible = true);
+    }
+  }
+
+  void _hidePassword() {
+    if (_isPasswordVisible) {
+      setState(() => _isPasswordVisible = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final primaryColor = theme.colorScheme.primary;
+    final effectiveObscureText = widget.obscureText && !_isPasswordVisible;
 
     return DecoratedBox(
       decoration: const BoxDecoration(
         border: Border(bottom: BorderSide(color: _fieldStroke)),
       ),
       child: TextFormField(
-        controller: controller,
-        keyboardType: keyboardType,
-        obscureText: obscureText,
-        textInputAction: textInputAction,
-        validator: validator,
-        onFieldSubmitted: onFieldSubmitted,
+        controller: widget.controller,
+        keyboardType: widget.keyboardType,
+        obscureText: effectiveObscureText,
+        textInputAction: widget.textInputAction,
+        validator: widget.validator,
+        onFieldSubmitted: widget.onFieldSubmitted,
         cursorColor: primaryColor,
         style: theme.textTheme.bodyLarge?.copyWith(
           color: const Color(0xFF202124),
@@ -264,7 +292,7 @@ class _LoginTextField extends StatelessWidget {
           letterSpacing: .25,
         ),
         decoration: InputDecoration(
-          labelText: labelText,
+          labelText: widget.labelText,
           floatingLabelStyle: theme.textTheme.bodySmall?.copyWith(
             color: primaryColor,
             fontSize: 12,
@@ -282,6 +310,51 @@ class _LoginTextField extends StatelessWidget {
           focusedErrorBorder: InputBorder.none,
           filled: false,
           contentPadding: const EdgeInsets.symmetric(vertical: 18),
+          suffixIcon: widget.obscureText
+              ? _PasswordVisibilityHoldIcon(
+                  visible: _isPasswordVisible,
+                  onPressStart: _showPassword,
+                  onPressEnd: _hidePassword,
+                )
+              : null,
+        ),
+      ),
+    );
+  }
+}
+
+class _PasswordVisibilityHoldIcon extends StatelessWidget {
+  const _PasswordVisibilityHoldIcon({
+    required this.visible,
+    required this.onPressStart,
+    required this.onPressEnd,
+  });
+
+  final bool visible;
+  final VoidCallback onPressStart;
+  final VoidCallback onPressEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.opaque,
+      onPointerDown: (_) => onPressStart(),
+      onPointerUp: (_) => onPressEnd(),
+      onPointerCancel: (_) => onPressEnd(),
+      child: Tooltip(
+        message: 'Hold to show password',
+        child: Semantics(
+          label: 'Hold to show password',
+          button: true,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Icon(
+              visible
+                  ? Icons.visibility_off_outlined
+                  : Icons.visibility_outlined,
+              color: _mutedText,
+            ),
+          ),
         ),
       ),
     );

--- a/test/login_screen_test.dart
+++ b/test/login_screen_test.dart
@@ -6,10 +6,12 @@ import 'package:finestar_mail/features/auth/domain/entities/connection_settings.
 import 'package:finestar_mail/features/auth/domain/entities/mail_account.dart';
 import 'package:finestar_mail/features/auth/domain/repositories/auth_repository.dart';
 import 'package:finestar_mail/features/auth/presentation/login_screen.dart';
+import 'package:finestar_mail/features/notifications/data/device_registration_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
 
 void main() {
   testWidgets('login screen uses main-screen style content', (tester) async {
@@ -42,6 +44,77 @@ void main() {
     expect(find.text('Password is required.'), findsOneWidget);
   });
 
+  testWidgets('password reveal is press-and-hold only', (tester) async {
+    await tester.pumpWidget(_buildTestApp(_FakeAuthRepository()));
+    await tester.pumpAndSettle();
+
+    final eyeIcon = find.byTooltip('Hold to show password');
+
+    expect(_passwordEditableText(tester).obscureText, isTrue);
+    expect(eyeIcon, findsOneWidget);
+
+    final gesture = await tester.createGesture();
+    await gesture.down(tester.getCenter(eyeIcon));
+    await tester.pump();
+
+    expect(_passwordEditableText(tester).obscureText, isFalse);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(_passwordEditableText(tester).obscureText, isTrue);
+  });
+
+  testWidgets('password reveal hides again after pointer cancel', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildTestApp(_FakeAuthRepository()));
+    await tester.pumpAndSettle();
+
+    final eyeIcon = find.byTooltip('Hold to show password');
+
+    final gesture = await tester.createGesture();
+    await gesture.down(tester.getCenter(eyeIcon));
+    await tester.pump();
+
+    expect(_passwordEditableText(tester).obscureText, isFalse);
+
+    await gesture.cancel();
+    await tester.pump();
+
+    expect(_passwordEditableText(tester).obscureText, isTrue);
+  });
+
+  testWidgets('holding password eye does not steal password field focus', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildTestApp(_FakeAuthRepository()));
+    await tester.pumpAndSettle();
+
+    final passwordField = find.byType(TextFormField).at(2);
+    final eyeIcon = find.byTooltip('Hold to show password');
+
+    await tester.tap(passwordField);
+    await tester.enterText(passwordField, 'secret');
+    await tester.pump();
+
+    expect(tester.testTextInput.isVisible, isTrue);
+    expect(_passwordEditableText(tester).obscureText, isTrue);
+
+    final gesture = await tester.createGesture();
+    await gesture.down(tester.getCenter(eyeIcon));
+    await tester.pump();
+
+    expect(tester.testTextInput.isVisible, isTrue);
+    expect(_passwordEditableText(tester).obscureText, isFalse);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(tester.testTextInput.isVisible, isTrue);
+    expect(_passwordEditableText(tester).obscureText, isTrue);
+  });
+
   testWidgets('add account still navigates to inbox on success', (
     tester,
   ) async {
@@ -62,6 +135,15 @@ void main() {
   });
 }
 
+EditableText _passwordEditableText(WidgetTester tester) {
+  return tester.widget<EditableText>(
+    find.descendant(
+      of: find.byType(TextFormField).at(2),
+      matching: find.byType(EditableText),
+    ),
+  );
+}
+
 Widget _buildTestApp(_FakeAuthRepository repository) {
   final router = GoRouter(
     initialLocation: AppRoute.login.path,
@@ -79,8 +161,28 @@ Widget _buildTestApp(_FakeAuthRepository repository) {
   );
 
   return ProviderScope(
-    overrides: [authRepositoryProvider.overrideWith((ref) => repository)],
+    overrides: [
+      authRepositoryProvider.overrideWith((ref) => repository),
+      deviceRegistrationServiceProvider.overrideWith(
+        (ref) => _disabledDeviceRegistrationService(),
+      ),
+    ],
     child: MaterialApp.router(theme: buildAppTheme(), routerConfig: router),
+  );
+}
+
+DeviceRegistrationService _disabledDeviceRegistrationService() {
+  return DeviceRegistrationService(
+    config: const DeviceRegistrationConfig(
+      apiBaseUrl: '',
+      registrationSecret: '',
+    ),
+    httpClient: http.Client(),
+    fcmTokenLoader: () async => null,
+    authTokenLoader: (_) async => null,
+    permissionRequester: () async {},
+    appVersionLoader: () async => 'test',
+    platform: 'test',
   );
 }
 


### PR DESCRIPTION
﻿## Summary
- add a press-and-hold eye affordance to the login password field
- reveal the password only during pointer down, then hide on pointer up/cancel
- keep password input focus, validation, and submit flow unchanged

## Tests
- flutter test test\login_screen_test.dart
- flutter analyze
- flutter test

Fixes #72
