### PR TITLE
[codex] Bump app version for closed testing

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+3
+version: 1.0.3+4
 
 environment:
   sdk: ^3.11.1


### PR DESCRIPTION
﻿## Summary
- bump app version from 1.0.2+3 to 1.0.3+4 for Google Play closed testing

## Tests
- flutter build appbundle --release

## Notes
- Release AAB was built at build\app\outputs\bundle\release\app-release.aab before opening this PR.
