### PR TITLE
[codex] Add contact suggestions API layer

### DIFF
--- a/lib/app/providers.dart
+++ b/lib/app/providers.dart
@@ -13,6 +13,8 @@ import '../features/attachments/domain/repositories/attachment_repository.dart';
 import '../features/auth/data/backend_auth_token_selector.dart';
 import '../features/auth/data/auth_repository_impl.dart';
 import '../features/auth/domain/repositories/auth_repository.dart';
+import '../features/contacts/data/contacts_repository_impl.dart';
+import '../features/contacts/domain/repositories/contacts_repository.dart';
 import '../features/compose/data/compose_repository_impl.dart';
 import '../features/compose/domain/repositories/compose_repository.dart';
 import '../features/mailbox/data/mailbox_repository_impl.dart';
@@ -61,6 +63,14 @@ final composeRepositoryProvider = Provider<ComposeRepository>((ref) {
     logger: ref.watch(loggerProvider),
     secureStorageService: ref.watch(secureStorageServiceProvider),
     backendMailApiClient: ref.watch(backendMailApiClientProvider),
+  );
+});
+
+final contactsRepositoryProvider = Provider<ContactsRepository>((ref) {
+  return ContactsRepositoryImpl(
+    backendMailApiClient: ref.watch(backendMailApiClientProvider),
+    backendAuthTokenSelector: ref.watch(backendAuthTokenSelectorProvider),
+    logger: ref.watch(loggerProvider),
   );
 });
 

--- a/lib/data/remote/backend_mail_api_client.dart
+++ b/lib/data/remote/backend_mail_api_client.dart
@@ -53,6 +53,20 @@ class BackendMailApiClient {
     return BackendAccountSummariesResponse.fromJson(json);
   }
 
+  Future<BackendContactSuggestionsResponse> contactSuggestions({
+    required String token,
+    required String query,
+    int limit = 20,
+  }) async {
+    final json = await _requestJson(
+      method: 'GET',
+      path: '/api/contacts/suggest',
+      queryParameters: {'q': query.trim(), 'limit': '$limit'},
+      token: token,
+    );
+    return BackendContactSuggestionsResponse.fromJson(json);
+  }
+
   Future<BackendFoldersResponse> folders({required String token}) async {
     final json = await _requestJson(
       method: 'GET',
@@ -553,6 +567,59 @@ class BackendAccountSummaryDto {
   }
 }
 
+class BackendContactSuggestionsResponse {
+  const BackendContactSuggestionsResponse({required this.contacts});
+
+  final List<BackendContactDto> contacts;
+
+  factory BackendContactSuggestionsResponse.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return BackendContactSuggestionsResponse(
+      contacts: _listOfObjects(
+        json['contacts'],
+      ).map(BackendContactDto.fromJson).toList(),
+    );
+  }
+}
+
+class BackendContactDto {
+  const BackendContactDto({
+    required this.id,
+    required this.email,
+    required this.displayName,
+    required this.source,
+    required this.timesContacted,
+    required this.lastUsedAt,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final int id;
+  final String email;
+  final String? displayName;
+  final String source;
+  final int timesContacted;
+  final DateTime? lastUsedAt;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  factory BackendContactDto.fromJson(Map<String, dynamic> json) {
+    return BackendContactDto(
+      id: json['id'] is num ? (json['id'] as num).toInt() : 0,
+      email: json['email'] as String? ?? '',
+      displayName: json['display_name'] as String?,
+      source: json['source'] as String? ?? '',
+      timesContacted: json['times_contacted'] is num
+          ? (json['times_contacted'] as num).toInt()
+          : 0,
+      lastUsedAt: _dateTime(json['last_used_at']),
+      createdAt: _dateTime(json['created_at']),
+      updatedAt: _dateTime(json['updated_at']),
+    );
+  }
+}
+
 class BackendFoldersResponse {
   const BackendFoldersResponse({
     required this.accountEmail,
@@ -735,9 +802,9 @@ class BackendUnifiedConversationsResponse {
   ) {
     return BackendUnifiedConversationsResponse(
       accountEmail: json['account_email'] as String? ?? '',
-      folders: _listOfObjects(json['folders'])
-          .map(BackendFolderDto.fromJson)
-          .toList(),
+      folders: _listOfObjects(
+        json['folders'],
+      ).map(BackendFolderDto.fromJson).toList(),
       conversations: _listOfObjects(
         json['conversations'],
       ).map(BackendUnifiedConversationDto.fromJson).toList(),

--- a/lib/features/contacts/data/contacts_repository_impl.dart
+++ b/lib/features/contacts/data/contacts_repository_impl.dart
@@ -1,0 +1,62 @@
+import 'package:logger/logger.dart';
+
+import '../../../data/remote/backend_mail_api_client.dart';
+import '../../auth/data/backend_auth_token_selector.dart';
+import '../domain/entities/contact_suggestion.dart';
+import '../domain/repositories/contacts_repository.dart';
+
+class ContactsRepositoryImpl implements ContactsRepository {
+  const ContactsRepositoryImpl({
+    required BackendMailApiClient backendMailApiClient,
+    required BackendAuthTokenSelector backendAuthTokenSelector,
+    Logger? logger,
+  }) : _backendMailApiClient = backendMailApiClient,
+       _backendAuthTokenSelector = backendAuthTokenSelector,
+       _logger = logger;
+
+  final BackendMailApiClient _backendMailApiClient;
+  final BackendAuthTokenSelector _backendAuthTokenSelector;
+  final Logger? _logger;
+
+  @override
+  Future<List<ContactSuggestion>> suggestContacts(String query) async {
+    final trimmedQuery = query.trim();
+    if (trimmedQuery.length < 3) {
+      return const [];
+    }
+
+    try {
+      final selectedToken = await _backendAuthTokenSelector.selectToken();
+      if (selectedToken == null) {
+        return const [];
+      }
+
+      final response = await _backendMailApiClient.contactSuggestions(
+        token: selectedToken.token,
+        query: trimmedQuery,
+      );
+      return response.contacts
+          .where((contact) => contact.email.trim().isNotEmpty)
+          .map(
+            (contact) => ContactSuggestion(
+              id: contact.id,
+              email: contact.email,
+              displayName: contact.displayName,
+              source: contact.source,
+              timesContacted: contact.timesContacted,
+              lastUsedAt: contact.lastUsedAt,
+              createdAt: contact.createdAt,
+              updatedAt: contact.updatedAt,
+            ),
+          )
+          .toList();
+    } catch (error, stackTrace) {
+      _logger?.w(
+        'Contact suggestions fetch failed.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return const [];
+    }
+  }
+}

--- a/lib/features/contacts/domain/entities/contact_suggestion.dart
+++ b/lib/features/contacts/domain/entities/contact_suggestion.dart
@@ -1,0 +1,31 @@
+class ContactSuggestion {
+  const ContactSuggestion({
+    required this.id,
+    required this.email,
+    required this.displayName,
+    required this.source,
+    required this.timesContacted,
+    required this.lastUsedAt,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final int id;
+  final String email;
+  final String? displayName;
+  final String source;
+  final int timesContacted;
+  final DateTime? lastUsedAt;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  String get displayLabel {
+    final name = displayName?.trim();
+    return name == null || name.isEmpty ? email : name;
+  }
+
+  String get recipientText {
+    final name = displayName?.trim();
+    return name == null || name.isEmpty ? email : '$name <$email>';
+  }
+}

--- a/lib/features/contacts/domain/repositories/contacts_repository.dart
+++ b/lib/features/contacts/domain/repositories/contacts_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/contact_suggestion.dart';
+
+abstract class ContactsRepository {
+  Future<List<ContactSuggestion>> suggestContacts(String query);
+}

--- a/test/backend_mail_api_client_test.dart
+++ b/test/backend_mail_api_client_test.dart
@@ -463,6 +463,81 @@ void main() {
     expect(response.accounts.single.importantCount, 3);
   });
 
+  test('contactSuggestions sends query limit and parses contacts', () async {
+    http.Request? capturedRequest;
+    final client = BackendMailApiClient(
+      httpClient: MockClient((request) async {
+        capturedRequest = request;
+        return http.Response(
+          jsonEncode({
+            'contacts': [
+              {
+                'id': 7,
+                'email': 'client@example.test',
+                'display_name': 'Client Name',
+                'source': 'manual',
+                'times_contacted': 4,
+                'last_used_at': '2026-04-22T20:30:00Z',
+                'created_at': '2026-04-20T08:00:00Z',
+                'updated_at': '2026-04-22T20:30:00Z',
+              },
+              {
+                'id': 8,
+                'email': 'plain@example.test',
+                'display_name': null,
+                'source': 'auto',
+                'times_contacted': 1,
+                'last_used_at': null,
+                'created_at': '2026-04-21T08:00:00Z',
+                'updated_at': '2026-04-21T08:00:00Z',
+              },
+            ],
+          }),
+          200,
+        );
+      }),
+      baseUrlLoader: () async => 'https://mail.example.test',
+    );
+
+    final response = await client.contactSuggestions(
+      token: 'session-token',
+      query: ' cli ',
+      limit: 10,
+    );
+
+    expect(capturedRequest?.method, 'GET');
+    expect(capturedRequest?.url.path, '/api/contacts/suggest');
+    expect(capturedRequest?.url.queryParameters, {'q': 'cli', 'limit': '10'});
+    expect(capturedRequest?.headers['Authorization'], 'Token session-token');
+    expect(response.contacts.first.id, 7);
+    expect(response.contacts.first.email, 'client@example.test');
+    expect(response.contacts.first.displayName, 'Client Name');
+    expect(response.contacts.first.source, 'manual');
+    expect(response.contacts.first.timesContacted, 4);
+    expect(
+      response.contacts.first.lastUsedAt,
+      DateTime.parse('2026-04-22T20:30:00Z'),
+    );
+    expect(response.contacts.last.displayName, isNull);
+    expect(response.contacts.last.lastUsedAt, isNull);
+  });
+
+  test('contactSuggestions parses empty response', () async {
+    final client = BackendMailApiClient(
+      httpClient: MockClient((request) async {
+        return http.Response(jsonEncode({'contacts': []}), 200);
+      }),
+      baseUrlLoader: () async => 'https://mail.example.test',
+    );
+
+    final response = await client.contactSuggestions(
+      token: 'session-token',
+      query: 'missing',
+    );
+
+    expect(response.contacts, isEmpty);
+  });
+
   test('message detail parses attachment metadata', () async {
     final client = BackendMailApiClient(
       httpClient: MockClient((request) async {

--- a/test/contacts_repository_test.dart
+++ b/test/contacts_repository_test.dart
@@ -1,0 +1,180 @@
+import 'dart:convert';
+
+import 'package:finestar_mail/core/result/result.dart';
+import 'package:finestar_mail/data/remote/backend_mail_api_client.dart';
+import 'package:finestar_mail/data/secure/secure_storage_service.dart';
+import 'package:finestar_mail/features/auth/data/backend_auth_token_selector.dart';
+import 'package:finestar_mail/features/auth/domain/entities/connection_settings.dart';
+import 'package:finestar_mail/features/auth/domain/entities/mail_account.dart';
+import 'package:finestar_mail/features/auth/domain/repositories/auth_repository.dart';
+import 'package:finestar_mail/features/contacts/data/contacts_repository_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  test(
+    'suggestContacts skips backend before three trimmed characters',
+    () async {
+      var requestCount = 0;
+      final repository = _buildRepository(
+        storage: _MemorySecureStorageService(activeAccountId: _account.id)
+          ..tokens[_account.id] = 'session-token',
+        httpClient: MockClient((request) async {
+          requestCount++;
+          return http.Response(jsonEncode({'contacts': []}), 200);
+        }),
+      );
+
+      final suggestions = await repository.suggestContacts(' ab ');
+
+      expect(suggestions, isEmpty);
+      expect(requestCount, 0);
+    },
+  );
+
+  test(
+    'suggestContacts fetches suggestions with active account token',
+    () async {
+      http.Request? capturedRequest;
+      final repository = _buildRepository(
+        storage: _MemorySecureStorageService(activeAccountId: _account.id)
+          ..tokens[_account.id] = 'session-token',
+        httpClient: MockClient((request) async {
+          capturedRequest = request;
+          return http.Response(
+            jsonEncode({
+              'contacts': [
+                {
+                  'id': 7,
+                  'email': 'client@example.test',
+                  'display_name': 'Client Name',
+                  'source': 'manual',
+                  'times_contacted': 3,
+                  'last_used_at': '2026-04-22T20:30:00Z',
+                  'created_at': '2026-04-20T08:00:00Z',
+                  'updated_at': '2026-04-22T20:30:00Z',
+                },
+              ],
+            }),
+            200,
+          );
+        }),
+      );
+
+      final suggestions = await repository.suggestContacts(' cli ');
+
+      expect(capturedRequest?.url.path, '/api/contacts/suggest');
+      expect(capturedRequest?.url.queryParameters['q'], 'cli');
+      expect(capturedRequest?.headers['Authorization'], 'Token session-token');
+      expect(suggestions.single.displayLabel, 'Client Name');
+      expect(
+        suggestions.single.recipientText,
+        'Client Name <client@example.test>',
+      );
+    },
+  );
+
+  test('suggestContacts returns empty when account token is missing', () async {
+    var requestCount = 0;
+    final repository = _buildRepository(
+      storage: _MemorySecureStorageService(activeAccountId: _account.id),
+      httpClient: MockClient((request) async {
+        requestCount++;
+        return http.Response(jsonEncode({'contacts': []}), 200);
+      }),
+    );
+
+    final suggestions = await repository.suggestContacts('client');
+
+    expect(suggestions, isEmpty);
+    expect(requestCount, 0);
+  });
+
+  test('suggestContacts returns empty when backend request fails', () async {
+    final repository = _buildRepository(
+      storage: _MemorySecureStorageService(activeAccountId: _account.id)
+        ..tokens[_account.id] = 'session-token',
+      httpClient: MockClient((request) async {
+        return http.Response(jsonEncode({'error': 'not_authenticated'}), 401);
+      }),
+    );
+
+    final suggestions = await repository.suggestContacts('client');
+
+    expect(suggestions, isEmpty);
+  });
+}
+
+ContactsRepositoryImpl _buildRepository({
+  required _MemorySecureStorageService storage,
+  required http.Client httpClient,
+}) {
+  return ContactsRepositoryImpl(
+    backendMailApiClient: BackendMailApiClient(
+      httpClient: httpClient,
+      baseUrlLoader: () async => 'https://mail.example.test',
+    ),
+    backendAuthTokenSelector: BackendAuthTokenSelector(
+      authRepository: _FakeAuthRepository([_account]),
+      secureStorageService: storage,
+    ),
+  );
+}
+
+const _settings = ConnectionSettings(
+  imapHost: 'mail.finestar.hr',
+  imapPort: 993,
+  imapSecurity: MailSecurity.sslTls,
+  smtpHost: 'mail.finestar.hr',
+  smtpPort: 465,
+  smtpSecurity: MailSecurity.sslTls,
+);
+
+final _account = MailAccount(
+  id: 'app-test-1@finestar.hr',
+  email: 'app-test-1@finestar.hr',
+  displayName: 'App Test',
+  connectionSettings: _settings,
+  createdAt: DateTime(2026, 4, 16),
+);
+
+class _MemorySecureStorageService extends SecureStorageService {
+  _MemorySecureStorageService({this.activeAccountId});
+
+  String? activeAccountId;
+  final tokens = <String, String>{};
+
+  @override
+  Future<String?> readActiveAccountId() async => activeAccountId;
+
+  @override
+  Future<String?> readAuthToken(String accountId) async => tokens[accountId];
+}
+
+class _FakeAuthRepository implements AuthRepository {
+  const _FakeAuthRepository(this.accounts);
+
+  final List<MailAccount> accounts;
+
+  @override
+  Future<List<MailAccount>> getAccounts() async => accounts;
+
+  @override
+  Future<MailAccount?> getActiveAccount() async => null;
+
+  @override
+  Future<void> setActiveAccount(String accountId) async {}
+
+  @override
+  Future<Result<MailAccount>> addAccount({
+    required String email,
+    required String displayName,
+    required String password,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> removeAccount(String accountId) async {}
+}


### PR DESCRIPTION
## Summary
- add `/api/contacts/suggest` support to `BackendMailApiClient`
- add contact suggestion domain/repository layer and Riverpod provider
- cover API parsing, token selection, short-query skipping, missing-token handling, and backend error fallback in tests

## Context
This is the first technical slice for mailserver issue #40. It intentionally avoids compose UI changes so the next PR can focus on autocomplete behavior and dropdown UX.

## Validation
- `flutter test test\backend_mail_api_client_test.dart test\contacts_repository_test.dart`
- `flutter analyze`

Kluster was not run because this repo's AGENTS.md says no Kluster tool is available and not to run Kluster verification.